### PR TITLE
Iterator and Async support

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -43,6 +43,7 @@
     <Compile Include="ClassWithPrivateMethod.cs" />
     <Compile Include="InterfaceBadAttributes.cs" />
     <Compile Include="SampleClass.cs" />
+    <Compile Include="SpecialClass.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj">

--- a/AssemblyToProcess/SpecialClass.cs
+++ b/AssemblyToProcess/SpecialClass.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NullGuard;
+
+public class SpecialClass
+{
+    public IEnumerable<int> CountTo(int end)
+    {
+        for (int i = 0; i < end; i++)
+        {
+            yield return i;
+        }
+    }
+
+    public async Task SomeMethodAsync(string nonNullArg, [AllowNull] string nullArg)
+    {
+        await Task.Run(() => Console.WriteLine(nonNullArg));
+    }
+
+    public async Task<string> MethodWithReturnValueAsync(bool returnNull)
+    {
+        return await Task.Run<string>(() => returnNull ? null : "");
+    }
+}

--- a/Fody/AssemblyProcessor.cs
+++ b/Fody/AssemblyProcessor.cs
@@ -6,7 +6,7 @@ public partial class ModuleWeaver
     {
         foreach (var type in types)
         {
-            if (type.ContainsAllowNullAttribute())
+            if (type.ContainsAllowNullAttribute() || type.IsCompilerGenerated())
             {
                 continue;
             }

--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -24,7 +24,6 @@ public static class CecilExtensions
         return type.Properties.Where(x => (x.GetMethod == null || !x.GetMethod.IsAbstract) && (x.SetMethod == null || !x.SetMethod.IsAbstract));
     }
 
-
     public static CustomAttribute GetNullGuardAttribute(this ICustomAttributeProvider value)
     {
         return value.CustomAttributes.FirstOrDefault(a => a.AttributeType.Name == "NullGuardAttribute");
@@ -43,5 +42,15 @@ public static class CecilExtensions
     public static bool MayNotBeNull(this ParameterDefinition arg)
     {
         return !arg.AllowsNull() && !arg.IsOptional && !arg.ParameterType.IsValueType && !arg.IsOut;
+    }
+
+    public static bool IsCompilerGenerated(this ICustomAttributeProvider value)
+    {
+        return value.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute");
+    }
+
+    public static bool IsAsyncStateMachine(this ICustomAttributeProvider value)
+    {
+        return value.CustomAttributes.Any(a => a.AttributeType.Name == "AsyncStateMachineAttribute");
     }
 }

--- a/Fody/MethodProcessor.cs
+++ b/Fody/MethodProcessor.cs
@@ -28,13 +28,11 @@ public class MethodProcessor
     {
         var validationFlags = ModuleWeaver.ValidationFlags;
 
-
-            var attribute = Method.DeclaringType.GetNullGuardAttribute();
-            if (attribute != null)
-            {
-                validationFlags = (ValidationFlags)attribute.ConstructorArguments[0].Value;
-            }
-        
+        var attribute = Method.DeclaringType.GetNullGuardAttribute();
+        if (attribute != null)
+        {
+            validationFlags = (ValidationFlags)attribute.ConstructorArguments[0].Value;
+        }
 
         if ((!validationFlags.HasFlag(ValidationFlags.NonPublic) && !Method.IsPublic)
             || Method.IsProperty()
@@ -49,7 +47,8 @@ public class MethodProcessor
             InjectMethodArgumentGuards(validationFlags);
         }
 
-        if (validationFlags.HasFlag(ValidationFlags.ReturnValues) &&
+        if (!Method.IsAsyncStateMachine() &&
+            validationFlags.HasFlag(ValidationFlags.ReturnValues) &&
             !Method.MethodReturnType.AllowsNull() &&
             !Method.ReturnType.IsValueType &&
             Method.ReturnType.FullName != typeof(void).FullName)
@@ -63,7 +62,6 @@ public class MethodProcessor
 
     void InjectMethodArgumentGuards(ValidationFlags validationFlags)
     {
-
         foreach (var parameter in Method.Parameters.Reverse())
         {
             if (parameter.MayNotBeNull())


### PR DESCRIPTION
Adding a return guard for an iterator does no harm since the value returned is the state machine which shouldn't be null anyway. So #5 is done.

Turned off adding code for compiler generated classes (iterator and async state machines).

Turned off return guard code generation for async methods as I'm not sure how to guard for null in an async method anyway.
