### PR TITLE
Reordering of custom attributes in the test assertions

### DIFF
--- a/Tests/ApprovedTests.SpecialClass.approved.txt
+++ b/Tests/ApprovedTests.SpecialClass.approved.txt
@@ -778,11 +778,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 64   // nValueAsync>d__d
                                                                                                                                        00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodWithReturnValueAsync>d__d' V_0,
@@ -845,10 +845,10 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<int32> 
           NoAwaitCode() cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1F 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                        3C 4E 6F 41 77 61 69 74 43 6F 64 65 3E 64 5F 5F   // <NoAwaitCode>d__
                                                                                                                                        31 33 00 00 )                                     // 13..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       58 (0x3a)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<NoAwaitCode>d__13' V_0,

--- a/Tests/ApprovedTests.SpecialClassNoAssert.approved.txt
+++ b/Tests/ApprovedTests.SpecialClassNoAssert.approved.txt
@@ -750,11 +750,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 64   // nValueAsync>d__d
                                                                                                                                        00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodWithReturnValueAsync>d__d' V_0,
@@ -817,10 +817,10 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<int32> 
           NoAwaitCode() cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1F 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                        3C 4E 6F 41 77 61 69 74 43 6F 64 65 3E 64 5F 5F   // <NoAwaitCode>d__
                                                                                                                                        31 33 00 00 )                                     // 13..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       58 (0x3a)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<NoAwaitCode>d__13' V_0,

--- a/Tests/Helpers/AssemblyWeaver.cs
+++ b/Tests/Helpers/AssemblyWeaver.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using Mono.Cecil;
+using Mono.Collections.Generic;
 
 public static class AssemblyWeaver
 {
@@ -146,9 +148,32 @@ public static class AssemblyWeaver
 
         weaveAction(moduleDefinition);
 
+        // This is necessary because we assert the order of method custom attributes (e.g. asserted IL code in ApprovedTests) although
+        // the order of custom attributes is not specified (see http://stackoverflow.com/questions/480007). Mono Cecil preserves the order.
+        foreach (var type in moduleDefinition.GetTypes())
+            ReorderMethodCustomAttributes(type);
+
         moduleDefinition.Write(afterAssemblyPath, writerParameters);
 
         return Assembly.LoadFile(afterAssemblyPath);
+    }
+
+    private static void ReorderMethodCustomAttributes(TypeDefinition type)
+    {
+        foreach (var methodDefinition in type.Methods)
+            ReorderCustomAttributes(methodDefinition.CustomAttributes);
+    }
+
+    private static void ReorderCustomAttributes(Collection<CustomAttribute> customAttributes)
+    {
+        if (customAttributes.Count > 1)
+        {
+            var sortedAttributes = customAttributes.OrderBy(x => x.AttributeType.FullName).ToList();
+
+            customAttributes.Clear();
+            foreach (var customAttribute in sortedAttributes)
+                customAttributes.Add(customAttribute);
+        }
     }
 
     private static void LogInfo(string error)


### PR DESCRIPTION
This is necessary because we assert the order of method custom attributes (e.g. asserted IL code in ApprovedTests) although the order of custom attributes is not specified (see http://stackoverflow.comquestions/480007). Mono Cecil preserves the order.

Otherwise the `ApprovedTests.SpecialClass` and `SpecialClassNoAssert` fails on my system (VS 2013).
