### PR TITLE
Moved reordering of custom attributes from AssemblyWeaver to ApprovedTests

### DIFF
--- a/Tests/ApprovedTests.SpecialClass.approved.txt
+++ b/Tests/ApprovedTests.SpecialClass.approved.txt
@@ -729,10 +729,10 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 37 00 00 )                            // >d__7..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       102 (0x66)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<SomeMethodAsync>d__7' V_0,
@@ -778,11 +778,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 64   // nValueAsync>d__d
                                                                                                                                        00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodWithReturnValueAsync>d__d' V_0,
@@ -813,11 +813,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodAllowsNullReturnValueAsync() cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 34 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..4SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 41 6C 6C 6F 77 73 4E 75 6C   // <MethodAllowsNul
                                                                                                                                        6C 52 65 74 75 72 6E 56 61 6C 75 65 41 73 79 6E   // lReturnValueAsyn
                                                                                                                                        63 3E 64 5F 5F 31 30 00 00 )                      // c>d__10..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       58 (0x3a)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodAllowsNullReturnValueAsync>d__10' V_0,

--- a/Tests/ApprovedTests.SpecialClassNoAssert.approved.txt
+++ b/Tests/ApprovedTests.SpecialClassNoAssert.approved.txt
@@ -709,10 +709,10 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 37 00 00 )                            // >d__7..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       85 (0x55)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<SomeMethodAsync>d__7' V_0,
@@ -750,11 +750,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 64   // nValueAsync>d__d
                                                                                                                                        00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodWithReturnValueAsync>d__d' V_0,
@@ -785,11 +785,11 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodAllowsNullReturnValueAsync() cil managed
   {
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 34 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..4SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 41 6C 6C 6F 77 73 4E 75 6C   // <MethodAllowsNul
                                                                                                                                        6C 52 65 74 75 72 6E 56 61 6C 75 65 41 73 79 6E   // lReturnValueAsyn
                                                                                                                                        63 3E 64 5F 5F 31 30 00 00 )                      // c>d__10..
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerStepThroughAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       58 (0x3a)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<MethodAllowsNullReturnValueAsync>d__10' V_0,

--- a/Tests/ApprovedTests.cs
+++ b/Tests/ApprovedTests.cs
@@ -123,10 +123,19 @@ public class ApprovedTests
 
             process.WaitForExit(10000);
 
-            return string.Join(Environment.NewLine, Regex.Split(process.StandardOutput.ReadToEnd(), Environment.NewLine)
+            string ilText = string.Join(Environment.NewLine, Regex.Split(process.StandardOutput.ReadToEnd(), Environment.NewLine)
                     .Where(l => !l.StartsWith("// ") && !string.IsNullOrEmpty(l))
                     .Select(l => l.Replace(projectFolder, ""))
                     .ToList());
+
+            // Sort the custom attributes in the generated IL code because the order of custom attributes is not specified (see 
+            // http://stackoverflow.com/questions/480007) and not stable.
+            ilText = Regex.Replace(
+                    ilText,
+                    @"(?<CustomInstance>\.custom instance void.*= *\([^)]+\)(?<SpaceOrComment>\s*|\s*//.*\s*)){2,}",
+                    match => string.Join("", match.Groups["CustomInstance"].Captures.Cast<Capture>().Select(x => x.Value).OrderBy(x => x.Trim())));
+
+            return ilText;
         }
     }
 

--- a/Tests/Helpers/AssemblyWeaver.cs
+++ b/Tests/Helpers/AssemblyWeaver.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using Mono.Cecil;
-using Mono.Collections.Generic;
 
 public static class AssemblyWeaver
 {
@@ -148,32 +146,9 @@ public static class AssemblyWeaver
 
         weaveAction(moduleDefinition);
 
-        // This is necessary because we assert the order of method custom attributes (e.g. asserted IL code in ApprovedTests) although
-        // the order of custom attributes is not specified (see http://stackoverflow.com/questions/480007). Mono Cecil preserves the order.
-        foreach (var type in moduleDefinition.GetTypes())
-            ReorderMethodCustomAttributes(type);
-
         moduleDefinition.Write(afterAssemblyPath, writerParameters);
 
         return Assembly.LoadFile(afterAssemblyPath);
-    }
-
-    private static void ReorderMethodCustomAttributes(TypeDefinition type)
-    {
-        foreach (var methodDefinition in type.Methods)
-            ReorderCustomAttributes(methodDefinition.CustomAttributes);
-    }
-
-    private static void ReorderCustomAttributes(Collection<CustomAttribute> customAttributes)
-    {
-        if (customAttributes.Count > 1)
-        {
-            var sortedAttributes = customAttributes.OrderBy(x => x.AttributeType.FullName).ToList();
-
-            customAttributes.Clear();
-            foreach (var customAttribute in sortedAttributes)
-                customAttributes.Add(customAttribute);
-        }
     }
 
     private static void LogInfo(string error)


### PR DESCRIPTION
... because the the custom attribute order of Cecil isn't stable.
