### PR TITLE
Inject null checks after base call in constructors

### DIFF
--- a/AssemblyToProcess/SimpleClass.cs
+++ b/AssemblyToProcess/SimpleClass.cs
@@ -3,6 +3,8 @@ using NullGuard;
 
 public class SimpleClass
 {
+    public string Field1;
+
     public SimpleClass()
     {
     }
@@ -16,6 +18,14 @@ public class SimpleClass
     public SimpleClass(string nonNullArg, [AllowNull] string nullArg)
     {
         Console.WriteLine(nonNullArg + " " + nullArg);
+    }
+
+    public SimpleClass(SimpleClass sc, SimpleClass sc1) : this(sc.Field1, null)
+    {
+    }
+
+    public SimpleClass(SimpleClass sc, SimpleClass sc1, SimpleClass sc2) : this(sc.Field1, sc2.NullProperty)
+    {
     }
 
     public SimpleClass(SimpleClass sc, string notUsed, string used) : this (sc.NullProperty, used)

--- a/AssemblyToProcess/SimpleClass.cs
+++ b/AssemblyToProcess/SimpleClass.cs
@@ -18,6 +18,10 @@ public class SimpleClass
         Console.WriteLine(nonNullArg + " " + nullArg);
     }
 
+    public SimpleClass(SimpleClass sc, string notUsed, string used) : this (sc.NullProperty, used)
+    {
+    }
+
     public void SomeMethod(string nonNullArg, [AllowNull] string nullArg)
     {
         Console.WriteLine(nonNullArg);

--- a/AssemblyToProcess/SimpleClass.cs
+++ b/AssemblyToProcess/SimpleClass.cs
@@ -22,6 +22,10 @@ public class SimpleClass
     {
     }
 
+    public SimpleClass(string astr, string str2, string str3) : this(int.Parse(astr).ToString(), null)
+    {
+    }
+
     public void SomeMethod(string nonNullArg, [AllowNull] string nullArg)
     {
         Console.WriteLine(nonNullArg);

--- a/Fody/MethodProcessor.cs
+++ b/Fody/MethodProcessor.cs
@@ -109,7 +109,7 @@ public class MethodProcessor
                 usedArgs = argsInstructions
                             .Where(i => method.Parameters.Contains(i.Operand) &&
                                         argsInstructions.SkipWhile(op => op != i).Skip(1)
-                                                        .Any(op => (op.OpCode == OpCodes.Call && op != call) || op.OpCode == OpCodes.Callvirt))
+                                                        .Any(op => (op.OpCode == OpCodes.Call && op != call) || op.OpCode == OpCodes.Callvirt || op.OpCode == OpCodes.Ldfld))
                             .Select(i => i.Operand as ParameterDefinition).ToList();
 
             }

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -60,25 +60,25 @@
   {
     // Code size       60 (0x3c)
     .maxstack  3
-    .line 16707566,16707566 : 0,0 ''
-    IL_0000:  ldarg.1
-    IL_0001:  ldnull
-    IL_0002:  ceq
-    IL_0004:  ldc.i4.0
-    IL_0005:  ceq
-    IL_0007:  ldstr      "[NullGuard] nonNullArg is null."
-    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
-                                                                       string)
-    IL_0011:  ldarg.1
-    IL_0012:  brtrue.s   IL_0024
-    IL_0014:  ldstr      "nonNullArg"
-    IL_0019:  ldstr      "[NullGuard] nonNullArg is null."
-    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
-                                                                                     string)
-    IL_0023:  throw
     .line 16,16 : 5,70 ''
-    IL_0024:  ldarg.0
-    IL_0025:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    .line 16707566,16707566 : 0,0 ''
+    IL_0006:  ldarg.1
+    IL_0007:  ldnull
+    IL_0008:  ceq
+    IL_000a:  ldc.i4.0
+    IL_000b:  ceq
+    IL_000d:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_0012:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0017:  ldarg.1
+    IL_0018:  brtrue.s   IL_002a
+    IL_001a:  ldstr      "nonNullArg"
+    IL_001f:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_0024:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0029:  throw
     .line 18,18 : 9,55 ''
     IL_002a:  ldarg.1
     IL_002b:  ldstr      " "

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -92,6 +92,120 @@
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor(class SimpleClass sc,
+                               class SimpleClass sc1) cil managed
+  {
+    // Code size       86 (0x56)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] sc is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "sc"
+    IL_0019:  ldstr      "[NullGuard] sc is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    .line 23,23 : 59,80 ''
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  ldfld      string SimpleClass::Field1
+    IL_002b:  ldnull
+    IL_002c:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0031:  ldarg.2
+    IL_0032:  ldnull
+    IL_0033:  ceq
+    IL_0035:  ldc.i4.0
+    IL_0036:  ceq
+    IL_0038:  ldstr      "[NullGuard] sc1 is null."
+    IL_003d:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0042:  ldarg.2
+    IL_0043:  brtrue.s   IL_0055
+    IL_0045:  ldstr      "sc1"
+    IL_004a:  ldstr      "[NullGuard] sc1 is null."
+    IL_004f:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0054:  throw
+    .line 25,25 : 5,6 ''
+    IL_0055:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
+                               class SimpleClass sc1,
+                               class SimpleClass sc2) cil managed
+  {
+    // Code size       127 (0x7f)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] sc is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "sc"
+    IL_0019:  ldstr      "[NullGuard] sc is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0024:  ldarg.3
+    IL_0025:  ldnull
+    IL_0026:  ceq
+    IL_0028:  ldc.i4.0
+    IL_0029:  ceq
+    IL_002b:  ldstr      "[NullGuard] sc2 is null."
+    IL_0030:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0035:  ldarg.3
+    IL_0036:  brtrue.s   IL_0048
+    IL_0038:  ldstr      "sc2"
+    IL_003d:  ldstr      "[NullGuard] sc2 is null."
+    IL_0042:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0047:  throw
+    .line 27,27 : 76,109 ''
+    IL_0048:  ldarg.0
+    IL_0049:  ldarg.1
+    IL_004a:  ldfld      string SimpleClass::Field1
+    IL_004f:  ldarg.3
+    IL_0050:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_0055:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_005a:  ldarg.2
+    IL_005b:  ldnull
+    IL_005c:  ceq
+    IL_005e:  ldc.i4.0
+    IL_005f:  ceq
+    IL_0061:  ldstr      "[NullGuard] sc1 is null."
+    IL_0066:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_006b:  ldarg.2
+    IL_006c:  brtrue.s   IL_007e
+    IL_006e:  ldstr      "sc1"
+    IL_0073:  ldstr      "[NullGuard] sc1 is null."
+    IL_0078:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_007d:  throw
+    .line 29,29 : 5,6 ''
+    IL_007e:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
                                string notUsed,
                                string used) cil managed
   {

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -113,47 +113,116 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 16707566,16707566 : 0,0 ''
-    IL_0024:  ldarg.3
-    IL_0025:  ldnull
-    IL_0026:  ceq
-    IL_0028:  ldc.i4.0
-    IL_0029:  ceq
-    IL_002b:  ldstr      "[NullGuard] used is null."
-    IL_0030:  call       void [System]System.Diagnostics.Debug::Assert(bool,
-                                                                       string)
-    IL_0035:  ldarg.3
-    IL_0036:  brtrue.s   IL_0048
-    IL_0038:  ldstr      "used"
-    IL_003d:  ldstr      "[NullGuard] used is null."
-    IL_0042:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
-                                                                                     string)
-    IL_0047:  throw
     .line 21,21 : 71,99 ''
-    IL_0048:  ldarg.0
-    IL_0049:  ldarg.1
-    IL_004a:  callvirt   instance string SimpleClass::get_NullProperty()
-    IL_004f:  ldarg.3
-    IL_0050:  call       instance void SimpleClass::.ctor(string,
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_002b:  ldarg.3
+    IL_002c:  call       instance void SimpleClass::.ctor(string,
                                                           string)
     .line 16707566,16707566 : 0,0 ''
-    IL_0055:  ldarg.2
+    IL_0031:  ldarg.2
+    IL_0032:  ldnull
+    IL_0033:  ceq
+    IL_0035:  ldc.i4.0
+    IL_0036:  ceq
+    IL_0038:  ldstr      "[NullGuard] notUsed is null."
+    IL_003d:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0042:  ldarg.2
+    IL_0043:  brtrue.s   IL_0055
+    IL_0045:  ldstr      "notUsed"
+    IL_004a:  ldstr      "[NullGuard] notUsed is null."
+    IL_004f:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0054:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0055:  ldarg.3
     IL_0056:  ldnull
     IL_0057:  ceq
     IL_0059:  ldc.i4.0
     IL_005a:  ceq
-    IL_005c:  ldstr      "[NullGuard] notUsed is null."
+    IL_005c:  ldstr      "[NullGuard] used is null."
     IL_0061:  call       void [System]System.Diagnostics.Debug::Assert(bool,
                                                                        string)
-    IL_0066:  ldarg.2
+    IL_0066:  ldarg.3
     IL_0067:  brtrue.s   IL_0079
-    IL_0069:  ldstr      "notUsed"
-    IL_006e:  ldstr      "[NullGuard] notUsed is null."
+    IL_0069:  ldstr      "used"
+    IL_006e:  ldstr      "[NullGuard] used is null."
     IL_0073:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0078:  throw
     .line 23,23 : 5,6 ''
     IL_0079:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(string astr,
+                               string str2,
+                               string str3) cil managed
+  {
+    // Code size       130 (0x82)
+    .maxstack  3
+    .locals init ([0] int32 )
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] astr is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "astr"
+    IL_0019:  ldstr      "[NullGuard] astr is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    .line 25,25 : 65,103 ''
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  call       int32 [mscorlib]System.Int32::Parse(string)
+    IL_002b:  stloc.0
+    IL_002c:  ldloca.s   
+    IL_002e:  call       instance string [mscorlib]System.Int32::ToString()
+    IL_0033:  ldnull
+    IL_0034:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0039:  ldarg.2
+    IL_003a:  ldnull
+    IL_003b:  ceq
+    IL_003d:  ldc.i4.0
+    IL_003e:  ceq
+    IL_0040:  ldstr      "[NullGuard] str2 is null."
+    IL_0045:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_004a:  ldarg.2
+    IL_004b:  brtrue.s   IL_005d
+    IL_004d:  ldstr      "str2"
+    IL_0052:  ldstr      "[NullGuard] str2 is null."
+    IL_0057:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_005c:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_005d:  ldarg.3
+    IL_005e:  ldnull
+    IL_005f:  ceq
+    IL_0061:  ldc.i4.0
+    IL_0062:  ceq
+    IL_0064:  ldstr      "[NullGuard] str3 is null."
+    IL_0069:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_006e:  ldarg.3
+    IL_006f:  brtrue.s   IL_0081
+    IL_0071:  ldstr      "str3"
+    IL_0076:  ldstr      "[NullGuard] str3 is null."
+    IL_007b:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0080:  throw
+    .line 27,27 : 5,6 ''
+    IL_0081:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
           SomeMethod(string nonNullArg,

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -90,6 +90,71 @@
     .line 19,19 : 5,6 ''
     IL_003b:  ret
   } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
+                               string notUsed,
+                               string used) cil managed
+  {
+    // Code size       122 (0x7a)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] sc is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "sc"
+    IL_0019:  ldstr      "[NullGuard] sc is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0024:  ldarg.3
+    IL_0025:  ldnull
+    IL_0026:  ceq
+    IL_0028:  ldc.i4.0
+    IL_0029:  ceq
+    IL_002b:  ldstr      "[NullGuard] used is null."
+    IL_0030:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0035:  ldarg.3
+    IL_0036:  brtrue.s   IL_0048
+    IL_0038:  ldstr      "used"
+    IL_003d:  ldstr      "[NullGuard] used is null."
+    IL_0042:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0047:  throw
+    .line 21,21 : 71,99 ''
+    IL_0048:  ldarg.0
+    IL_0049:  ldarg.1
+    IL_004a:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_004f:  ldarg.3
+    IL_0050:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0055:  ldarg.2
+    IL_0056:  ldnull
+    IL_0057:  ceq
+    IL_0059:  ldc.i4.0
+    IL_005a:  ceq
+    IL_005c:  ldstr      "[NullGuard] notUsed is null."
+    IL_0061:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0066:  ldarg.2
+    IL_0067:  brtrue.s   IL_0079
+    IL_0069:  ldstr      "notUsed"
+    IL_006e:  ldstr      "[NullGuard] notUsed is null."
+    IL_0073:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0078:  throw
+    .line 23,23 : 5,6 ''
+    IL_0079:  ret
+  } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
           SomeMethod(string nonNullArg,
                      string nullArg) cil managed

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -1,6 +1,7 @@
 ﻿.class public auto ansi beforefieldinit SimpleClass
        extends [mscorlib]System.Object
 {
+  .field public string Field1
   .field private string '<NonNullProperty>k__BackingField'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<NullProperty>k__BackingField'
@@ -17,10 +18,10 @@
     // Code size       7 (0x7)
     .maxstack  1
     .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 6,6 : 5,25 'AssemblyToProcess\\SimpleClass.cs'
+    .line 8,8 : 5,25 'AssemblyToProcess\\SimpleClass.cs'
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-    .line 8,8 : 5,6 ''
+    .line 10,10 : 5,6 ''
     IL_0006:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -28,10 +29,10 @@
   {
     // Code size       43 (0x2b)
     .maxstack  2
-    .line 11,11 : 5,49 ''
+    .line 13,13 : 5,49 ''
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-    .line 13,13 : 9,30 ''
+    .line 15,15 : 9,30 ''
     IL_0006:  ldarg.1
     IL_0007:  ldnull
     IL_0008:  stind.ref
@@ -51,7 +52,7 @@
     IL_001f:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
     IL_0024:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0029:  throw
-    .line 14,14 : 5,6 ''
+    .line 16,16 : 5,6 ''
     IL_002a:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -60,7 +61,7 @@
   {
     // Code size       60 (0x3c)
     .maxstack  3
-    .line 16,16 : 5,70 ''
+    .line 18,18 : 5,70 ''
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     .line 16707566,16707566 : 0,0 ''
@@ -79,7 +80,7 @@
     IL_0024:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0029:  throw
-    .line 18,18 : 9,55 ''
+    .line 20,20 : 9,55 ''
     IL_002a:  ldarg.1
     IL_002b:  ldstr      " "
     IL_0030:  ldarg.2
@@ -87,7 +88,7 @@
                                                                 string,
                                                                 string)
     IL_0036:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 19,19 : 5,6 ''
+    .line 21,21 : 5,6 ''
     IL_003b:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -227,7 +228,7 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 21,21 : 71,99 ''
+    .line 31,31 : 71,99 ''
     IL_0024:  ldarg.0
     IL_0025:  ldarg.1
     IL_0026:  callvirt   instance string SimpleClass::get_NullProperty()
@@ -266,7 +267,7 @@
     IL_0073:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0078:  throw
-    .line 23,23 : 5,6 ''
+    .line 33,33 : 5,6 ''
     IL_0079:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -293,7 +294,7 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 25,25 : 65,103 ''
+    .line 35,35 : 65,103 ''
     IL_0024:  ldarg.0
     IL_0025:  ldarg.1
     IL_0026:  call       int32 [mscorlib]System.Int32::Parse(string)
@@ -335,7 +336,7 @@
     IL_007b:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0080:  throw
-    .line 27,27 : 5,6 ''
+    .line 37,37 : 5,6 ''
     IL_0081:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
@@ -360,10 +361,10 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 23,23 : 9,39 ''
+    .line 41,41 : 9,39 ''
     IL_0024:  ldarg.1
     IL_0025:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 24,24 : 5,6 ''
+    .line 42,42 : 5,6 ''
     IL_002a:  ret
   } // end of method SimpleClass::SomeMethod
   .method public hidebysig specialname instance string 
@@ -544,7 +545,7 @@
   {
     // Code size       75 (0x4b)
     .maxstack  3
-    .line 39,39 : 9,39 ''
+    .line 57,57 : 9,39 ''
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_0029
     IL_0003:  ldstr      ""
@@ -609,7 +610,7 @@
     IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0025:  throw
-    .line 44,44 : 5,6 ''
+    .line 62,62 : 5,6 ''
     IL_0026:  ret
   } // end of method SimpleClass::MethodWithRef
   .method public hidebysig instance void 
@@ -635,7 +636,7 @@
     IL_0028:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_002d:  throw
-    .line 48,48 : 5,6 ''
+    .line 66,66 : 5,6 ''
     IL_002e:  ret
   } // end of method SimpleClass::MethodWithGeneric
   .method public hidebysig instance void 
@@ -663,7 +664,7 @@
     IL_0032:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0037:  throw
-    .line 52,52 : 5,6 ''
+    .line 70,70 : 5,6 ''
     IL_0038:  ret
   } // end of method SimpleClass::MethodWithGenericRef
   .method public hidebysig instance string 
@@ -671,7 +672,7 @@
   {
     // Code size       2 (0x2)
     .maxstack  1
-    .line 57,57 : 9,21 ''
+    .line 75,75 : 9,21 ''
     IL_0000:  ldnull
     IL_0001:  ret
   } // end of method SimpleClass::MethodAllowsNullReturnValue
@@ -681,7 +682,7 @@
     .custom instance void CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       2 (0x2)
     .maxstack  1
-    .line 63,63 : 9,21 ''
+    .line 81,81 : 9,21 ''
     IL_0000:  ldnull
     IL_0001:  ret
   } // end of method SimpleClass::MethodWithCanBeNullResult
@@ -690,7 +691,7 @@
   {
     // Code size       37 (0x25)
     .maxstack  2
-    .line 68,68 : 9,30 ''
+    .line 86,86 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
@@ -710,7 +711,7 @@
     IL_0019:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
     IL_001e:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0023:  throw
-    .line 69,69 : 5,6 ''
+    .line 87,87 : 5,6 ''
     IL_0024:  ret
   } // end of method SimpleClass::MethodWithOutValue
   .method public hidebysig instance void 
@@ -718,11 +719,11 @@
   {
     // Code size       4 (0x4)
     .maxstack  2
-    .line 73,73 : 9,30 ''
+    .line 91,91 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 74,74 : 5,6 ''
+    .line 92,92 : 5,6 ''
     IL_0003:  ret
   } // end of method SimpleClass::MethodWithAllowedNullOutValue
   .method public hidebysig instance void 
@@ -730,11 +731,11 @@
   {
     // Code size       8 (0x8)
     .maxstack  2
-    .line 78,78 : 9,33 ''
+    .line 96,96 : 9,33 ''
     IL_0000:  ldarg.0
     IL_0001:  ldnull
     IL_0002:  call       instance void SimpleClass::SomePrivateMethod(string)
-    .line 79,79 : 5,6 ''
+    .line 97,97 : 5,6 ''
     IL_0007:  ret
   } // end of method SimpleClass::PublicWrapperOfPrivateMethod
   .method private hidebysig instance void 
@@ -742,10 +743,10 @@
   {
     // Code size       7 (0x7)
     .maxstack  8
-    .line 83,83 : 9,30 ''
+    .line 101,101 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 84,84 : 5,6 ''
+    .line 102,102 : 5,6 ''
     IL_0006:  ret
   } // end of method SimpleClass::SomePrivateMethod
   .method public hidebysig instance void 
@@ -790,7 +791,7 @@
     IL_0046:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_004b:  throw
-    .line 88,88 : 5,6 ''
+    .line 106,106 : 5,6 ''
     IL_004c:  ret
   } // end of method SimpleClass::MethodWithTwoRefs
   .method public hidebysig instance void 
@@ -799,11 +800,11 @@
   {
     // Code size       73 (0x49)
     .maxstack  2
-    .line 92,92 : 9,22 ''
+    .line 110,110 : 9,22 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 93,93 : 9,23 ''
+    .line 111,111 : 9,23 ''
     IL_0003:  ldarg.2
     IL_0004:  ldnull
     IL_0005:  stind.ref
@@ -839,7 +840,7 @@
     IL_003d:  ldstr      "[NullGuard] Out parameter 'second' is null."
     IL_0042:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0047:  throw
-    .line 94,94 : 5,6 ''
+    .line 112,112 : 5,6 ''
     IL_0048:  ret
   } // end of method SimpleClass::MethodWithTwoOuts
   .method public hidebysig instance void 
@@ -848,7 +849,7 @@
     .param [1] = nullref
     // Code size       1 (0x1)
     .maxstack  0
-    .line 98,98 : 5,6 ''
+    .line 116,116 : 5,6 ''
     IL_0000:  ret
   } // end of method SimpleClass::MethodWithOptionalParameter
   .method public hidebysig instance void 
@@ -873,7 +874,7 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 102,102 : 5,6 ''
+    .line 120,120 : 5,6 ''
     IL_0024:  ret
   } // end of method SimpleClass::MethodWithOptionalParameterWithNonNullDefaultValue
   .method public hidebysig instance void 
@@ -882,7 +883,7 @@
     .param [1] = "default"
     // Code size       1 (0x1)
     .maxstack  0
-    .line 106,106 : 5,6 ''
+    .line 124,124 : 5,6 ''
     IL_0000:  ret
   } // end of method SimpleClass::MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute
   .method public hidebysig instance void 
@@ -890,7 +891,7 @@
   {
     // Code size       59 (0x3b)
     .maxstack  2
-    .line 110,110 : 9,27 ''
+    .line 128,128 : 9,27 ''
     IL_0000:  ldarg.1
     IL_0001:  initobj    !!T
     .line 16707566,16707566 : 0,0 ''
@@ -911,7 +912,7 @@
     IL_002f:  ldstr      "[NullGuard] Out parameter 'item' is null."
     IL_0034:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0039:  throw
-    .line 111,111 : 5,6 ''
+    .line 129,129 : 5,6 ''
     IL_003a:  ret
   } // end of method SimpleClass::MethodWithGenericOut
   .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
@@ -919,7 +920,7 @@
     // Code size       103 (0x67)
     .maxstack  3
     .locals init ([0] !!T CS$0$0000)
-    .line 115,115 : 9,72 ''
+    .line 133,133 : 9,72 ''
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_0033
     IL_0003:  call       !!0 [mscorlib]System.Activator::CreateInstance<!!0>()
@@ -972,11 +973,11 @@
   {
     // Code size       70 (0x46)
     .maxstack  3
-    .line 120,120 : 9,23 ''
+    .line 138,138 : 9,23 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 121,121 : 9,21 ''
+    .line 139,139 : 9,21 ''
     IL_0003:  ldnull
     .line 16707566,16707566 : 0,0 ''
     IL_0004:  ldarg.1
@@ -1034,20 +1035,20 @@
     IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0023:  throw
-    .line 126,126 : 9,37 ''
+    .line 144,144 : 9,37 ''
     IL_0024:  ldarg.1
     IL_0025:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_002a:  brfalse.s  IL_003c
-    .line 127,127 : 13,69 ''
+    .line 145,145 : 13,69 ''
     IL_002c:  ldstr      "x is null or empty."
     IL_0031:  ldstr      "x"
     IL_0036:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string,
                                                                                  string)
     IL_003b:  throw
-    .line 129,129 : 9,30 ''
+    .line 147,147 : 9,30 ''
     IL_003c:  ldarg.1
     IL_003d:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 130,130 : 5,6 ''
+    .line 148,148 : 5,6 ''
     IL_0042:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentGuard
   .method public hidebysig instance void 
@@ -1055,18 +1056,18 @@
   {
     // Code size       26 (0x1a)
     .maxstack  1
-    .line 134,134 : 9,37 ''
+    .line 152,152 : 9,37 ''
     IL_0000:  ldarg.1
     IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_0006:  brfalse.s  IL_0013
-    .line 135,135 : 13,50 ''
+    .line 153,153 : 13,50 ''
     IL_0008:  ldstr      "x"
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
     IL_0012:  throw
-    .line 137,137 : 9,30 ''
+    .line 155,155 : 9,30 ''
     IL_0013:  ldarg.1
     IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 138,138 : 5,6 ''
+    .line 156,156 : 5,6 ''
     IL_0019:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentNullGuard
   .method public hidebysig instance void 
@@ -1074,20 +1075,20 @@
   {
     // Code size       31 (0x1f)
     .maxstack  2
-    .line 142,142 : 9,37 ''
+    .line 160,160 : 9,37 ''
     IL_0000:  ldarg.1
     IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_0006:  brfalse.s  IL_0018
-    .line 143,143 : 13,73 ''
+    .line 161,161 : 13,73 ''
     IL_0008:  ldstr      "x"
     IL_000d:  ldstr      "x is null or empty."
     IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0017:  throw
-    .line 145,145 : 9,30 ''
+    .line 163,163 : 9,30 ''
     IL_0018:  ldarg.1
     IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 146,146 : 5,6 ''
+    .line 164,164 : 5,6 ''
     IL_001e:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentNullGuardWithMessage
   .property instance string NonNullProperty()

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -1,6 +1,7 @@
 ﻿.class public auto ansi beforefieldinit SimpleClass
        extends [mscorlib]System.Object
 {
+  .field public string Field1
   .field private string '<NonNullProperty>k__BackingField'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<NullProperty>k__BackingField'
@@ -17,10 +18,10 @@
     // Code size       7 (0x7)
     .maxstack  1
     .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 6,6 : 5,25 'AssemblyToProcess\\SimpleClass.cs'
+    .line 8,8 : 5,25 'AssemblyToProcess\\SimpleClass.cs'
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-    .line 8,8 : 5,6 ''
+    .line 10,10 : 5,6 ''
     IL_0006:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -28,10 +29,10 @@
   {
     // Code size       25 (0x19)
     .maxstack  2
-    .line 11,11 : 5,49 ''
+    .line 13,13 : 5,49 ''
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-    .line 13,13 : 9,30 ''
+    .line 15,15 : 9,30 ''
     IL_0006:  ldarg.1
     IL_0007:  ldnull
     IL_0008:  stind.ref
@@ -42,7 +43,7 @@
     IL_000d:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
     IL_0012:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0017:  throw
-    .line 14,14 : 5,6 ''
+    .line 16,16 : 5,6 ''
     IL_0018:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -51,7 +52,7 @@
   {
     // Code size       43 (0x2b)
     .maxstack  3
-    .line 16,16 : 5,70 ''
+    .line 18,18 : 5,70 ''
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     .line 16707566,16707566 : 0,0 ''
@@ -62,7 +63,7 @@
     IL_0013:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0018:  throw
-    .line 18,18 : 9,55 ''
+    .line 20,20 : 9,55 ''
     IL_0019:  ldarg.1
     IL_001a:  ldstr      " "
     IL_001f:  ldarg.2
@@ -70,7 +71,7 @@
                                                                 string,
                                                                 string)
     IL_0025:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 19,19 : 5,6 ''
+    .line 21,21 : 5,6 ''
     IL_002a:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -162,7 +163,7 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 21,21 : 71,99 ''
+    .line 31,31 : 71,99 ''
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
     IL_0015:  callvirt   instance string SimpleClass::get_NullProperty()
@@ -185,7 +186,7 @@
     IL_0040:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0045:  throw
-    .line 23,23 : 5,6 ''
+    .line 33,33 : 5,6 ''
     IL_0046:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
@@ -204,7 +205,7 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 25,25 : 65,103 ''
+    .line 35,35 : 65,103 ''
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
     IL_0015:  call       int32 [mscorlib]System.Int32::Parse(string)
@@ -230,7 +231,7 @@
     IL_0048:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_004d:  throw
-    .line 27,27 : 5,6 ''
+    .line 37,37 : 5,6 ''
     IL_004e:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
@@ -247,10 +248,10 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 23,23 : 9,39 ''
+    .line 41,41 : 9,39 ''
     IL_0013:  ldarg.1
     IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 24,24 : 5,6 ''
+    .line 42,42 : 5,6 ''
     IL_0019:  ret
   } // end of method SimpleClass::SomeMethod
   .method public hidebysig specialname instance string 
@@ -394,7 +395,7 @@
   {
     // Code size       41 (0x29)
     .maxstack  2
-    .line 39,39 : 9,39 ''
+    .line 57,57 : 9,39 ''
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_0018
     IL_0003:  ldstr      ""
@@ -432,7 +433,7 @@
     IL_000e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0013:  throw
-    .line 44,44 : 5,6 ''
+    .line 62,62 : 5,6 ''
     IL_0014:  ret
   } // end of method SimpleClass::MethodWithRef
   .method public hidebysig instance void 
@@ -449,7 +450,7 @@
     IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0017:  throw
-    .line 48,48 : 5,6 ''
+    .line 66,66 : 5,6 ''
     IL_0018:  ret
   } // end of method SimpleClass::MethodWithGeneric
   .method public hidebysig instance void 
@@ -467,7 +468,7 @@
     IL_0017:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_001c:  throw
-    .line 52,52 : 5,6 ''
+    .line 70,70 : 5,6 ''
     IL_001d:  ret
   } // end of method SimpleClass::MethodWithGenericRef
   .method public hidebysig instance string 
@@ -475,7 +476,7 @@
   {
     // Code size       2 (0x2)
     .maxstack  1
-    .line 57,57 : 9,21 ''
+    .line 75,75 : 9,21 ''
     IL_0000:  ldnull
     IL_0001:  ret
   } // end of method SimpleClass::MethodAllowsNullReturnValue
@@ -485,7 +486,7 @@
     .custom instance void CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       2 (0x2)
     .maxstack  1
-    .line 63,63 : 9,21 ''
+    .line 81,81 : 9,21 ''
     IL_0000:  ldnull
     IL_0001:  ret
   } // end of method SimpleClass::MethodWithCanBeNullResult
@@ -494,7 +495,7 @@
   {
     // Code size       19 (0x13)
     .maxstack  2
-    .line 68,68 : 9,30 ''
+    .line 86,86 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
@@ -505,7 +506,7 @@
     IL_0007:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
     IL_000c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0011:  throw
-    .line 69,69 : 5,6 ''
+    .line 87,87 : 5,6 ''
     IL_0012:  ret
   } // end of method SimpleClass::MethodWithOutValue
   .method public hidebysig instance void 
@@ -513,11 +514,11 @@
   {
     // Code size       4 (0x4)
     .maxstack  2
-    .line 73,73 : 9,30 ''
+    .line 91,91 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 74,74 : 5,6 ''
+    .line 92,92 : 5,6 ''
     IL_0003:  ret
   } // end of method SimpleClass::MethodWithAllowedNullOutValue
   .method public hidebysig instance void 
@@ -525,11 +526,11 @@
   {
     // Code size       8 (0x8)
     .maxstack  2
-    .line 78,78 : 9,33 ''
+    .line 96,96 : 9,33 ''
     IL_0000:  ldarg.0
     IL_0001:  ldnull
     IL_0002:  call       instance void SimpleClass::SomePrivateMethod(string)
-    .line 79,79 : 5,6 ''
+    .line 97,97 : 5,6 ''
     IL_0007:  ret
   } // end of method SimpleClass::PublicWrapperOfPrivateMethod
   .method private hidebysig instance void 
@@ -537,10 +538,10 @@
   {
     // Code size       7 (0x7)
     .maxstack  8
-    .line 83,83 : 9,30 ''
+    .line 101,101 : 9,30 ''
     IL_0000:  ldarg.1
     IL_0001:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 84,84 : 5,6 ''
+    .line 102,102 : 5,6 ''
     IL_0006:  ret
   } // end of method SimpleClass::SomePrivateMethod
   .method public hidebysig instance void 
@@ -567,7 +568,7 @@
     IL_0022:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0027:  throw
-    .line 88,88 : 5,6 ''
+    .line 106,106 : 5,6 ''
     IL_0028:  ret
   } // end of method SimpleClass::MethodWithTwoRefs
   .method public hidebysig instance void 
@@ -576,11 +577,11 @@
   {
     // Code size       37 (0x25)
     .maxstack  2
-    .line 92,92 : 9,22 ''
+    .line 110,110 : 9,22 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 93,93 : 9,23 ''
+    .line 111,111 : 9,23 ''
     IL_0003:  ldarg.2
     IL_0004:  ldnull
     IL_0005:  stind.ref
@@ -598,7 +599,7 @@
     IL_0019:  ldstr      "[NullGuard] Out parameter 'second' is null."
     IL_001e:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0023:  throw
-    .line 94,94 : 5,6 ''
+    .line 112,112 : 5,6 ''
     IL_0024:  ret
   } // end of method SimpleClass::MethodWithTwoOuts
   .method public hidebysig instance void 
@@ -607,7 +608,7 @@
     .param [1] = nullref
     // Code size       1 (0x1)
     .maxstack  0
-    .line 98,98 : 5,6 ''
+    .line 116,116 : 5,6 ''
     IL_0000:  ret
   } // end of method SimpleClass::MethodWithOptionalParameter
   .method public hidebysig instance void 
@@ -624,7 +625,7 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 102,102 : 5,6 ''
+    .line 120,120 : 5,6 ''
     IL_0013:  ret
   } // end of method SimpleClass::MethodWithOptionalParameterWithNonNullDefaultValue
   .method public hidebysig instance void 
@@ -633,7 +634,7 @@
     .param [1] = "default"
     // Code size       1 (0x1)
     .maxstack  0
-    .line 106,106 : 5,6 ''
+    .line 124,124 : 5,6 ''
     IL_0000:  ret
   } // end of method SimpleClass::MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute
   .method public hidebysig instance void 
@@ -641,7 +642,7 @@
   {
     // Code size       32 (0x20)
     .maxstack  1
-    .line 110,110 : 9,27 ''
+    .line 128,128 : 9,27 ''
     IL_0000:  ldarg.1
     IL_0001:  initobj    !!T
     .line 16707566,16707566 : 0,0 ''
@@ -652,7 +653,7 @@
     IL_0014:  ldstr      "[NullGuard] Out parameter 'item' is null."
     IL_0019:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_001e:  throw
-    .line 111,111 : 5,6 ''
+    .line 129,129 : 5,6 ''
     IL_001f:  ret
   } // end of method SimpleClass::MethodWithGenericOut
   .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
@@ -660,7 +661,7 @@
     // Code size       59 (0x3b)
     .maxstack  2
     .locals init ([0] !!T CS$0$0000)
-    .line 115,115 : 9,72 ''
+    .line 133,133 : 9,72 ''
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_001d
     IL_0003:  call       !!0 [mscorlib]System.Activator::CreateInstance<!!0>()
@@ -693,11 +694,11 @@
   {
     // Code size       35 (0x23)
     .maxstack  2
-    .line 120,120 : 9,23 ''
+    .line 138,138 : 9,23 ''
     IL_0000:  ldarg.1
     IL_0001:  ldnull
     IL_0002:  stind.ref
-    .line 121,121 : 9,21 ''
+    .line 139,139 : 9,21 ''
     IL_0003:  ldnull
     .line 16707566,16707566 : 0,0 ''
     IL_0004:  ldarg.1
@@ -729,20 +730,20 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 126,126 : 9,37 ''
+    .line 144,144 : 9,37 ''
     IL_0013:  ldarg.1
     IL_0014:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_0019:  brfalse.s  IL_002b
-    .line 127,127 : 13,69 ''
+    .line 145,145 : 13,69 ''
     IL_001b:  ldstr      "x is null or empty."
     IL_0020:  ldstr      "x"
     IL_0025:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string,
                                                                                  string)
     IL_002a:  throw
-    .line 129,129 : 9,30 ''
+    .line 147,147 : 9,30 ''
     IL_002b:  ldarg.1
     IL_002c:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 130,130 : 5,6 ''
+    .line 148,148 : 5,6 ''
     IL_0031:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentGuard
   .method public hidebysig instance void 
@@ -750,18 +751,18 @@
   {
     // Code size       26 (0x1a)
     .maxstack  1
-    .line 134,134 : 9,37 ''
+    .line 152,152 : 9,37 ''
     IL_0000:  ldarg.1
     IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_0006:  brfalse.s  IL_0013
-    .line 135,135 : 13,50 ''
+    .line 153,153 : 13,50 ''
     IL_0008:  ldstr      "x"
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
     IL_0012:  throw
-    .line 137,137 : 9,30 ''
+    .line 155,155 : 9,30 ''
     IL_0013:  ldarg.1
     IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 138,138 : 5,6 ''
+    .line 156,156 : 5,6 ''
     IL_0019:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentNullGuard
   .method public hidebysig instance void 
@@ -769,20 +770,20 @@
   {
     // Code size       31 (0x1f)
     .maxstack  2
-    .line 142,142 : 9,37 ''
+    .line 160,160 : 9,37 ''
     IL_0000:  ldarg.1
     IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
     IL_0006:  brfalse.s  IL_0018
-    .line 143,143 : 13,73 ''
+    .line 161,161 : 13,73 ''
     IL_0008:  ldstr      "x"
     IL_000d:  ldstr      "x is null or empty."
     IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0017:  throw
-    .line 145,145 : 9,30 ''
+    .line 163,163 : 9,30 ''
     IL_0018:  ldarg.1
     IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
-    .line 146,146 : 5,6 ''
+    .line 164,164 : 5,6 ''
     IL_001e:  ret
   } // end of method SimpleClass::MethodWithExistingArgumentNullGuardWithMessage
   .property instance string NonNullProperty()

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -75,6 +75,80 @@
   } // end of method SimpleClass::.ctor
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor(class SimpleClass sc,
+                               class SimpleClass sc1) cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "sc"
+    IL_0008:  ldstr      "[NullGuard] sc is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    .line 23,23 : 59,80 ''
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  ldfld      string SimpleClass::Field1
+    IL_001a:  ldnull
+    IL_001b:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0020:  ldarg.2
+    IL_0021:  brtrue.s   IL_0033
+    IL_0023:  ldstr      "sc1"
+    IL_0028:  ldstr      "[NullGuard] sc1 is null."
+    IL_002d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0032:  throw
+    .line 25,25 : 5,6 ''
+    IL_0033:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
+                               class SimpleClass sc1,
+                               class SimpleClass sc2) cil managed
+  {
+    // Code size       76 (0x4c)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "sc"
+    IL_0008:  ldstr      "[NullGuard] sc is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0013:  ldarg.3
+    IL_0014:  brtrue.s   IL_0026
+    IL_0016:  ldstr      "sc2"
+    IL_001b:  ldstr      "[NullGuard] sc2 is null."
+    IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0025:  throw
+    .line 27,27 : 76,109 ''
+    IL_0026:  ldarg.0
+    IL_0027:  ldarg.1
+    IL_0028:  ldfld      string SimpleClass::Field1
+    IL_002d:  ldarg.3
+    IL_002e:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_0033:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0038:  ldarg.2
+    IL_0039:  brtrue.s   IL_004b
+    IL_003b:  ldstr      "sc1"
+    IL_0040:  ldstr      "[NullGuard] sc1 is null."
+    IL_0045:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_004a:  throw
+    .line 29,29 : 5,6 ''
+    IL_004b:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
                                string notUsed,
                                string used) cil managed
   {

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -73,6 +73,47 @@
     .line 19,19 : 5,6 ''
     IL_002a:  ret
   } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(class SimpleClass sc,
+                               string notUsed,
+                               string used) cil managed
+  {
+    // Code size       71 (0x47)
+    .maxstack  3
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "sc"
+    IL_0008:  ldstr      "[NullGuard] sc is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0013:  ldarg.3
+    IL_0014:  brtrue.s   IL_0026
+    IL_0016:  ldstr      "used"
+    IL_001b:  ldstr      "[NullGuard] used is null."
+    IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0025:  throw
+    .line 21,21 : 71,99 ''
+    IL_0026:  ldarg.0
+    IL_0027:  ldarg.1
+    IL_0028:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_002d:  ldarg.3
+    IL_002e:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0033:  ldarg.2
+    IL_0034:  brtrue.s   IL_0046
+    IL_0036:  ldstr      "notUsed"
+    IL_003b:  ldstr      "[NullGuard] notUsed is null."
+    IL_0040:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0045:  throw
+    .line 23,23 : 5,6 ''
+    IL_0046:  ret
+  } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
           SomeMethod(string nonNullArg,
                      string nullArg) cil managed

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -51,17 +51,17 @@
   {
     // Code size       43 (0x2b)
     .maxstack  3
-    .line 16707566,16707566 : 0,0 ''
-    IL_0000:  ldarg.1
-    IL_0001:  brtrue.s   IL_0013
-    IL_0003:  ldstr      "nonNullArg"
-    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
-    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
-                                                                                     string)
-    IL_0012:  throw
     .line 16,16 : 5,70 ''
-    IL_0013:  ldarg.0
-    IL_0014:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    .line 16707566,16707566 : 0,0 ''
+    IL_0006:  ldarg.1
+    IL_0007:  brtrue.s   IL_0019
+    IL_0009:  ldstr      "nonNullArg"
+    IL_000e:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_0013:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0018:  throw
     .line 18,18 : 9,55 ''
     IL_0019:  ldarg.1
     IL_001a:  ldstr      " "

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -88,31 +88,76 @@
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
-    .line 16707566,16707566 : 0,0 ''
-    IL_0013:  ldarg.3
-    IL_0014:  brtrue.s   IL_0026
-    IL_0016:  ldstr      "used"
-    IL_001b:  ldstr      "[NullGuard] used is null."
-    IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
-                                                                                     string)
-    IL_0025:  throw
     .line 21,21 : 71,99 ''
-    IL_0026:  ldarg.0
-    IL_0027:  ldarg.1
-    IL_0028:  callvirt   instance string SimpleClass::get_NullProperty()
-    IL_002d:  ldarg.3
-    IL_002e:  call       instance void SimpleClass::.ctor(string,
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  callvirt   instance string SimpleClass::get_NullProperty()
+    IL_001a:  ldarg.3
+    IL_001b:  call       instance void SimpleClass::.ctor(string,
                                                           string)
     .line 16707566,16707566 : 0,0 ''
-    IL_0033:  ldarg.2
+    IL_0020:  ldarg.2
+    IL_0021:  brtrue.s   IL_0033
+    IL_0023:  ldstr      "notUsed"
+    IL_0028:  ldstr      "[NullGuard] notUsed is null."
+    IL_002d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0032:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_0033:  ldarg.3
     IL_0034:  brtrue.s   IL_0046
-    IL_0036:  ldstr      "notUsed"
-    IL_003b:  ldstr      "[NullGuard] notUsed is null."
+    IL_0036:  ldstr      "used"
+    IL_003b:  ldstr      "[NullGuard] used is null."
     IL_0040:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0045:  throw
     .line 23,23 : 5,6 ''
     IL_0046:  ret
+  } // end of method SimpleClass::.ctor
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(string astr,
+                               string str2,
+                               string str3) cil managed
+  {
+    // Code size       79 (0x4f)
+    .maxstack  3
+    .locals init ([0] int32 )
+    .line 16707566,16707566 : 0,0 ''
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "astr"
+    IL_0008:  ldstr      "[NullGuard] astr is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    .line 25,25 : 65,103 ''
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  call       int32 [mscorlib]System.Int32::Parse(string)
+    IL_001a:  stloc.0
+    IL_001b:  ldloca.s   
+    IL_001d:  call       instance string [mscorlib]System.Int32::ToString()
+    IL_0022:  ldnull
+    IL_0023:  call       instance void SimpleClass::.ctor(string,
+                                                          string)
+    .line 16707566,16707566 : 0,0 ''
+    IL_0028:  ldarg.2
+    IL_0029:  brtrue.s   IL_003b
+    IL_002b:  ldstr      "str2"
+    IL_0030:  ldstr      "[NullGuard] str2 is null."
+    IL_0035:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_003a:  throw
+    .line 16707566,16707566 : 0,0 ''
+    IL_003b:  ldarg.3
+    IL_003c:  brtrue.s   IL_004e
+    IL_003e:  ldstr      "str3"
+    IL_0043:  ldstr      "[NullGuard] str3 is null."
+    IL_0048:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_004d:  throw
+    .line 27,27 : 5,6 ''
+    IL_004e:  ret
   } // end of method SimpleClass::.ctor
   .method public hidebysig instance void 
           SomeMethod(string nonNullArg,


### PR DESCRIPTION
Fixes #51 

I've updated the tests as best I could, I'm running VS 2015 and the compiler is outputting different IL for certain things so I can't be certain that I've caught all the instances of classes with constructors calling base (or having base calls injected by the compiler).