### PR TITLE
[WIP] Injection of JetBrains Annotations

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -26,12 +26,16 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=9.2.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.9.2.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,7 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ReSharperAnnotations.cs" />
+    <Compile Include="SampleClassWithInvalidInjectJetBrainsAnnotations.cs" />
+    <Compile Include="SampleClassWithDisabledInjectJetBrainsAnnotations.cs" />
+    <Compile Include="Configuration.cs" />
     <Compile Include="ClassWithBadAttributes.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -76,6 +82,9 @@
       <Project>{B5AEB0E8-28F4-4955-A055-9C200F7113F0}</Project>
       <Name>ReferenceAssembly</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AssemblyToProcess/Configuration.cs
+++ b/AssemblyToProcess/Configuration.cs
@@ -1,0 +1,4 @@
+using JetBrains.Annotations;
+using NullGuard;
+
+[assembly: InjectJetBrainsAnnotations(typeof (NotNullAttribute), typeof (ItemNotNullAttribute))]

--- a/AssemblyToProcess/ReSharperAnnotations.cs
+++ b/AssemblyToProcess/ReSharperAnnotations.cs
@@ -1,8 +1,0 @@
-using System;
-
-[AttributeUsage (
-    AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Delegate,
-    AllowMultiple = false, Inherited = true)]
-public sealed class CanBeNullAttribute : Attribute
-{
-}

--- a/AssemblyToProcess/SampleClassWithDisabledInjectJetBrainsAnnotations.cs
+++ b/AssemblyToProcess/SampleClassWithDisabledInjectJetBrainsAnnotations.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using NullGuard;
+
+[InjectJetBrainsAnnotations(null, null)]
+public class SampleClassWithDisabledInjectJetBrainsAnnotations
+{
+    public string SomeMethod(string nonNullArg)
+    {
+        return null;
+    }
+
+    public async Task<string> SomeAsyncMethod ()
+    {
+        await Task.Delay(0);
+        return null;
+    }
+
+    public string SomeProperty { get; set; }
+}

--- a/AssemblyToProcess/SampleClassWithInvalidInjectJetBrainsAnnotations.cs
+++ b/AssemblyToProcess/SampleClassWithInvalidInjectJetBrainsAnnotations.cs
@@ -1,0 +1,6 @@
+﻿using NullGuard;
+
+[InjectJetBrainsAnnotations(typeof(string), typeof(int))]
+public class SampleClassWithInvalidInjectJetBrainsAnnotations
+{
+}

--- a/AssemblyToProcess/SimpleClass.cs
+++ b/AssemblyToProcess/SimpleClass.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 using NullGuard;
 
 public class SimpleClass
@@ -144,4 +145,13 @@ public class SimpleClass
 
         Console.WriteLine(x);
     }
+
+    [NotNull]
+    public string MethodWithNotNullAnnotations([NotNull] string nonNullArg)
+    {
+        return null;
+    }
+
+    [NotNull]
+    public string PropertyWithNotNullAnnotation { get; set; }
 }

--- a/AssemblyToProcess/packages.config
+++ b/AssemblyToProcess/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="9.2.0" targetFramework="net45" />
+</packages>

--- a/AssemblyToProcessWithoutJetBrainsAnnotations/AssemblyToProcessWithoutJetBrainsAnnotations.csproj
+++ b/AssemblyToProcessWithoutJetBrainsAnnotations/AssemblyToProcessWithoutJetBrainsAnnotations.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AssemblyToProcessWithoutJetBrainsAnnotations</RootNamespace>
+    <AssemblyName>AssemblyToProcessWithoutJetBrainsAnnotations</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SampleClassWithoutJetBrainsAnnotationsAttribute.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/AssemblyToProcessWithoutJetBrainsAnnotations/SampleClassWithoutJetBrainsAnnotationsAttribute.cs
+++ b/AssemblyToProcessWithoutJetBrainsAnnotations/SampleClassWithoutJetBrainsAnnotationsAttribute.cs
@@ -1,0 +1,9 @@
+﻿public class SampleClassWithoutJetBrainsAnnotationsAttribute
+{
+    public string SomeMethod(string nonNullArg)
+    {
+        return null;
+    }
+
+    public string SomeProperty { get; set; }
+}

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -82,6 +82,7 @@
     <Compile Include="..\ReferenceAssembly\ValidationFlags.cs">
       <Link>ValidationFlags.cs</Link>
     </Compile>
+    <Compile Include="JetBrainsAnnotationsApplier.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="InstructionPatterns.cs" />
     <Compile Include="CecilExtensions.cs" />

--- a/Fody/JetBrainsAnnotationsApplier.cs
+++ b/Fody/JetBrainsAnnotationsApplier.cs
@@ -1,0 +1,90 @@
+﻿using System.Linq;
+using Anotar.Custom;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+
+public class JetBrainsAnnotationsApplier
+{
+    private const string InjectJetBrainsAnnotationsAttributeType = "NullGuard.InjectJetBrainsAnnotationsAttribute";
+
+    private readonly CustomAttribute _notNullAttribute;
+    private readonly CustomAttribute _itemNotNullAttribute;
+
+    private JetBrainsAnnotationsApplier(CustomAttribute notNullAttribute, CustomAttribute itemNotNullAttribute)
+    {
+        _notNullAttribute = notNullAttribute;
+        _itemNotNullAttribute = itemNotNullAttribute;
+    }
+
+    public static JetBrainsAnnotationsApplier CreateForType(TypeDefinition type)
+    {
+        // Note that the InjectJetBrainsAnnotationsAttribute is defined as an (AllowMultiple=false) attribute
+        // with exactly two Type constructor parameters.
+
+        var configurationAttribute = GetInjectJetBrainsAnnotationsAttribute(type);
+
+        if (configurationAttribute == null)
+            return new JetBrainsAnnotationsApplier(null, null);
+
+        return new JetBrainsAnnotationsApplier(
+                GetReferencedAttribute(type.Module, configurationAttribute.ConstructorArguments[0]),
+                GetReferencedAttribute(type.Module, configurationAttribute.ConstructorArguments[1]));
+    }
+
+    private static CustomAttribute GetInjectJetBrainsAnnotationsAttribute(TypeDefinition type)
+    {
+        // Two-step attribute lookup for testing purposes and to make it symmetric with the way the NullGuard attribute works
+        return new[] { type.CustomAttributes, type.Module.Assembly.CustomAttributes }
+                .Select(x => x.SingleOrDefault(a => a.AttributeType.FullName == InjectJetBrainsAnnotationsAttributeType))
+                .FirstOrDefault(x => x != null);
+    }
+
+    private static CustomAttribute GetReferencedAttribute(ModuleDefinition module, CustomAttributeArgument referencedAttributeArgument)
+    {
+        var referencedAttributeType = (TypeReference) referencedAttributeArgument.Value;
+
+        if (referencedAttributeType == null)
+            return null;
+
+        var defaultConstructor = referencedAttributeType.Resolve().GetConstructors().SingleOrDefault(x => !x.HasParameters);
+
+        if (defaultConstructor == null)
+        {
+            LogTo.Error(
+                    $"{InjectJetBrainsAnnotationsAttributeType} referenced invalid annotation type '{referencedAttributeType}' " +
+                    "(doesn't contain an empty constructor).");
+            return null;
+        }
+
+        return new CustomAttribute(module.ImportReference(defaultConstructor));
+    }
+
+    public void AddToMethod(MethodDefinition method)
+    {
+        AddIfNotPresent(method, _notNullAttribute);
+    }
+
+    public void AddToAsyncMethod(MethodDefinition method)
+    {
+        AddIfNotPresent(method, _itemNotNullAttribute);
+    }
+
+    public void AddToParameter(ParameterDefinition parameter)
+    {
+        AddIfNotPresent(parameter, _notNullAttribute);
+    }
+
+    public void AddToProperty(PropertyDefinition property)
+    {
+        AddIfNotPresent(property, _notNullAttribute);
+    }
+
+    private static void AddIfNotPresent(ICustomAttributeProvider attributeProvider, CustomAttribute attribute)
+    {
+        if (attribute != null)
+        {
+            if (!attributeProvider.CustomAttributes.Any(x => x.AttributeType.FullName == attribute.AttributeType.FullName))
+                attributeProvider.CustomAttributes.Add(attribute);
+        }
+    }
+}

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -36,6 +36,8 @@ public class ModuleWeaver
 
         ReadConfig();
 
+        // REVIEW: Why do we check for module attributes (instead of just checking on assembly level) 
+        //         as the attribute targets are defined with AttributeTargets.Assembly | AttributeTargets.Class?
         var nullGuardAttribute = ModuleDefinition.GetNullGuardAttribute();
 
         if (nullGuardAttribute == null)
@@ -137,11 +139,13 @@ public class ModuleWeaver
             if (type.IsInterface || type.ContainsAllowNullAttribute() || type.IsGeneratedCode() || type.HasInterface("Windows.UI.Xaml.Markup.IXamlMetadataProvider"))
                 continue;
 
+            var jetBrainsAnnotationsApplier = JetBrainsAnnotationsApplier.CreateForType(type);
+
             foreach (var method in type.MethodsWithBody())
-                methodProcessor.Process(method);
+                methodProcessor.Process(method, jetBrainsAnnotationsApplier);
 
             foreach (var property in type.ConcreteProperties())
-                propertyProcessor.Process(property);
+                propertyProcessor.Process(property, jetBrainsAnnotationsApplier);
         }
     }
 

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fody", "Fody\Fody.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -18,6 +18,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceAssembly", "ReferenceAssembly\ReferenceAssembly.csproj", "{B5AEB0E8-28F4-4955-A055-9C200F7113F0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessMono", "AssemblyToProcessMono\AssemblyToProcessMono.csproj", "{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessWithoutJetBrainsAnnotations", "AssemblyToProcessWithoutJetBrainsAnnotations\AssemblyToProcessWithoutJetBrainsAnnotations.csproj", "{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +57,12 @@ Global
 		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Release|x86.ActiveCfg = Release|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52DDFE30-3A96-4078-B4CA-6C1DFA2724D1}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ReferenceAssembly/InjectJetBrainsAnnotationsAttribute.cs
+++ b/ReferenceAssembly/InjectJetBrainsAnnotationsAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace NullGuard
+{
+    /// <summary>
+    /// Attribute to configure injection of [NotNull]/[ItemNotNull] attributes for ReSharper's static nullability analysis.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class)]
+    public class InjectJetBrainsAnnotationsAttribute : Attribute
+    {
+        /// <summary>
+        /// Configure injection of [NotNull]/[ItemNotNull] attributes for ReSharper's static nullability analysis.
+        /// </summary>
+        /// <param name="notNullAttribute">
+        /// Reference to <see cref="T:JetBrains.Annotations.NotNullAttribute" />, used to inject this attribute
+        /// onto non-nullable methods, parameters, and properties. Use <see langword="null" /> to disable this injection.
+        /// </param>
+        /// <param name="itemNotNullAttribute">
+        /// Reference to <see cref="T:JetBrains.Annotations.ItemNotNullAttribute" />, used to inject this attribute
+        /// onto non-nullable <c>async</c> methods (supported by ReSharper 9.2+). Use <see langword="null" /> to disable this injection.
+        /// </param>
+        public InjectJetBrainsAnnotationsAttribute(Type notNullAttribute, Type itemNotNullAttribute)
+        {
+        }
+    }
+}

--- a/ReferenceAssembly/ReferenceAssembly.csproj
+++ b/ReferenceAssembly/ReferenceAssembly.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="AllowNullAttribute.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs" />
+    <Compile Include="InjectJetBrainsAnnotationsAttribute.cs" />
     <Compile Include="NullGuardAttribute.cs" />
     <Compile Include="ValidationFlags.cs" />
   </ItemGroup>

--- a/Tests/ApprovedTests.cs
+++ b/Tests/ApprovedTests.cs
@@ -96,6 +96,18 @@ public class ApprovedTests
     }
 
     [Test]
+    public void SampleClassWithDisabledInjectJetBrainsAnnotations()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "SampleClassWithDisabledInjectJetBrainsAnnotations"));
+    }
+
+    [Test]
+    public void SampleClassWithoutJetBrainsAnnotationsAttribute()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[3], "SampleClassWithoutJetBrainsAnnotationsAttribute"));
+    }
+
+    [Test]
     public void InfosList()
     {
         Approvals.VerifyAll(AssemblyWeaver.Infos.OrderBy(e => e), "Infos: ");

--- a/Tests/Helpers/Decompiler.cs
+++ b/Tests/Helpers/Decompiler.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 
@@ -24,50 +26,58 @@ public static class Decompiler
 		{
 			process.WaitForExit(10000);
 
-			var stringBuilder = new StringBuilder();
-			string line;
-			while ((line = process.StandardOutput.ReadLine())!=null)
-            {
-                if (line.Contains(".line "))
-                {
-                    continue;
-                }
-                if (line.Contains(".custom instance void ["))
-                {
-                    continue;
-                }
-                if (line.StartsWith("// "))
-                {
-                    continue;
-                }
-                if (line.Trim().Length == 0)
-                {
-                    continue;
-                }
-                if (line.StartsWith("  } // end of "))
-                {
-                    stringBuilder.AppendLine("  } ");
-                    continue;
-                }
-                if (line.StartsWith("} // end of "))
-                {
-                    stringBuilder.AppendLine("}");
-                    continue;
-                }
-                if (line.StartsWith("    .get instance "))
-                {
-                    continue;
-                }
-                if (line.StartsWith("    .set instance "))
-                {
-                    continue;
-                }
+            var ilText = process.StandardOutput.ReadToEnd();
 
-                stringBuilder.AppendLine(line);
-			}
-			return stringBuilder.ToString();
-		}
-	}
+            // Sort the custom attributes in the generated IL code because the order of custom attributes is not specified (see
+            // http://stackoverflow.com/questions/480007) and not stable.
+            ilText = Regex.Replace(
+                    ilText,
+                    @"(?<CustomInstance>[\t ]*\.custom instance void.*=[^)]+\).*((\r\n)|\n){1}){2,}",
+                    match => string.Join("", match.Groups["CustomInstance"].Captures.Cast<Capture>().Select(x => x.Value).OrderBy(x => x.Trim())));
+
+            var stringBuilder = new StringBuilder();
+            using (var reader = new StringReader(ilText))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line.Contains(".line "))
+                    {
+                        continue;
+                    }
+                    if (line.StartsWith("// "))
+                    {
+                        continue;
+                    }
+                    if (line.Trim().Length == 0)
+                    {
+                        continue;
+                    }
+                    if (line.StartsWith("  } // end of "))
+                    {
+                        stringBuilder.AppendLine("  } ");
+                        continue;
+                    }
+                    if (line.StartsWith("} // end of "))
+                    {
+                        stringBuilder.AppendLine("}");
+                        continue;
+                    }
+                    if (line.StartsWith("    .get instance "))
+                    {
+                        continue;
+                    }
+                    if (line.StartsWith("    .set instance "))
+                    {
+                        continue;
+                    }
+
+                    stringBuilder.AppendLine(line);
+                }
+                return stringBuilder.ToString();
+            }
+        }
+    }
 
 	static string GetPathToILDasm()
 	{

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -122,6 +122,8 @@
     <Content Include="approvals\ApprovedTests.InfosList.approved.txt" />
     <Content Include="approvals\ApprovedTests.InterfaceBadAttributes.approved.txt" />
     <Content Include="approvals\ApprovedTests.PublicNestedInsideNonPublic.approved.txt" />
+    <Content Include="approvals\ApprovedTests.SampleClassWithDisabledInjectJetBrainsAnnotations.approved.txt" />
+    <Content Include="approvals\ApprovedTests.SampleClassWithoutJetBrainsAnnotationsAttribute.approved.txt" />
     <Content Include="approvals\ApprovedTests.SimpleClass.approved.txt" />
     <Content Include="approvals\ApprovedTests.SimpleClassNoAssert.approved.txt" />
     <Content Include="approvals\ApprovedTests.SkipIXamlMetadataProvider.approved.txt" />

--- a/Tests/VerifyTest.cs
+++ b/Tests/VerifyTest.cs
@@ -22,6 +22,12 @@ public class VerifyTest
     {
         Verifier.Verify(AssemblyWeaver.MonoBeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[2]);
     }
+
+    [Test]
+    public void PeVerify4()
+    {
+        Verifier.Verify(AssemblyWeaver.WithoutJetBrainsAnnotationsAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[3]);
+    }
 }
 
 #endif

--- a/Tests/approvals/ApprovedTests.ClassWithPrivateMethod.approved.txt
+++ b/Tests/approvals/ApprovedTests.ClassWithPrivateMethod.approved.txt
@@ -2,6 +2,7 @@
        extends [mscorlib]System.Object
 {
   .field private string '<SomeProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig instance void 
           PublicWrapperOfPrivateMethod() cil managed
   {
@@ -38,6 +39,7 @@
   .method public hidebysig specialname instance string 
           get_SomeProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -47,6 +49,7 @@
   .method public hidebysig specialname instance void 
           set_SomeProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0

--- a/Tests/approvals/ApprovedTests.ClassWithPrivateMethod.approved.txt
+++ b/Tests/approvals/ApprovedTests.ClassWithPrivateMethod.approved.txt
@@ -17,6 +17,8 @@
   .method private hidebysig instance void 
           SomePrivateMethod(string x) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  2
     IL_0000:  ldarg.1

--- a/Tests/approvals/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
@@ -17,6 +17,8 @@
   .method private hidebysig instance void 
           SomePrivateMethod(string x) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  2
     IL_0000:  ldarg.1

--- a/Tests/approvals/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
@@ -2,6 +2,7 @@
        extends [mscorlib]System.Object
 {
   .field private string '<SomeProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig instance void 
           PublicWrapperOfPrivateMethod() cil managed
   {
@@ -30,6 +31,7 @@
   .method public hidebysig specialname instance string 
           get_SomeProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -39,6 +41,7 @@
   .method public hidebysig specialname instance void 
           set_SomeProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0

--- a/Tests/approvals/ApprovedTests.ErrorsList.approved.txt
+++ b/Tests/approvals/ApprovedTests.ErrorsList.approved.txt
@@ -6,3 +6,7 @@ Errors: [4] = Method 'System.Void InterfaceBadAttributes::MethodWithNoNullCheckO
 Errors: [5] = Method 'System.Void InterfaceBadAttributes::MethodWithNoNullCheckOnParam(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.
 Errors: [6] = Method 'System.Void InterfaceBadAttributes::set_PropertyWithNoNullCheckOnSet(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.
 Errors: [7] = Method 'System.Void InterfaceBadAttributes::set_PropertyWithNoNullCheckOnSet(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.
+Errors: [8] = NullGuard.InjectJetBrainsAnnotationsAttribute referenced invalid annotation type 'System.Int32' (doesn't contain an empty constructor).
+Errors: [9] = NullGuard.InjectJetBrainsAnnotationsAttribute referenced invalid annotation type 'System.Int32' (doesn't contain an empty constructor).
+Errors: [10] = NullGuard.InjectJetBrainsAnnotationsAttribute referenced invalid annotation type 'System.String' (doesn't contain an empty constructor).
+Errors: [11] = NullGuard.InjectJetBrainsAnnotationsAttribute referenced invalid annotation type 'System.String' (doesn't contain an empty constructor).

--- a/Tests/approvals/ApprovedTests.GenericClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.GenericClass.approved.txt
@@ -2,9 +2,11 @@
        extends [mscorlib]System.Object
 {
   .field private !T '<NonNullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname instance !T 
           get_NonNullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       49 (0x31)
     .maxstack  3
     .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
@@ -33,6 +35,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullProperty(!T 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       54 (0x36)
     .maxstack  2
     IL_0000:  ldarg.1

--- a/Tests/approvals/ApprovedTests.GenericClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.GenericClass.approved.txt
@@ -73,5 +73,6 @@
   } 
   .property instance !T NonNullProperty()
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
 }

--- a/Tests/approvals/ApprovedTests.GenericClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.GenericClassNoAssert.approved.txt
@@ -2,9 +2,11 @@
        extends [mscorlib]System.Object
 {
   .field private !T '<NonNullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname instance !T 
           get_NonNullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       27 (0x1b)
     .maxstack  2
     .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
@@ -23,6 +25,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullProperty(!T 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       32 (0x20)
     .maxstack  2
     IL_0000:  ldarg.1

--- a/Tests/approvals/ApprovedTests.GenericClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.GenericClassNoAssert.approved.txt
@@ -53,5 +53,6 @@
   } 
   .property instance !T NonNullProperty()
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
 }

--- a/Tests/approvals/ApprovedTests.Indexers.approved.txt
+++ b/Tests/approvals/ApprovedTests.Indexers.approved.txt
@@ -9,6 +9,10 @@
             instance string  get_Item(string nonNullParam1,
                                       string nonNullParam2) cil managed
     {
+      .param [1]
+      .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+      .param [2]
+      .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       110 (0x6e)
       .maxstack  3
       .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
@@ -66,6 +70,10 @@
                                     string nonNullParam2,
                                     string 'value') cil managed
     {
+      .param [1]
+      .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+      .param [2]
+      .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       109 (0x6d)
       .maxstack  2
       IL_0000:  ldarg.3
@@ -131,6 +139,7 @@
     .property instance string Item(string,
                                    string)
     {
+      .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance string Indexers/NonNullable::get_Item(string,
                                                           string)
       .set instance void Indexers/NonNullable::set_Item(string,

--- a/Tests/approvals/ApprovedTests.Indexers.approved.txt
+++ b/Tests/approvals/ApprovedTests.Indexers.approved.txt
@@ -4,6 +4,7 @@
   .class auto ansi nested public beforefieldinit NonNullable
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
     .method public hidebysig specialname 
             instance string  get_Item(string nonNullParam1,
                                       string nonNullParam2) cil managed
@@ -140,6 +141,7 @@
   .class auto ansi nested public beforefieldinit PassThroughGetterReturnValue
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
     .method public hidebysig specialname 
             instance string  get_Item(string returnValue) cil managed
     {
@@ -181,6 +183,7 @@
   .class auto ansi nested public beforefieldinit AllowedNulls
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
     .method public hidebysig specialname 
             instance string  get_Item(string allowNull,
                                       valuetype [mscorlib]System.Nullable`1<int32> nullableInt,

--- a/Tests/approvals/ApprovedTests.InfosList.approved.txt
+++ b/Tests/approvals/ApprovedTests.InfosList.approved.txt
@@ -1,3 +1,4 @@
 ﻿Infos: [0] = 	No reference to 'NullGuard.dll' found. References not modified.
-Infos: [1] = 	Removing reference to 'NullGuard.dll'.
+Infos: [1] = 	No reference to 'NullGuard.dll' found. References not modified.
 Infos: [2] = 	Removing reference to 'NullGuard.dll'.
+Infos: [3] = 	Removing reference to 'NullGuard.dll'.

--- a/Tests/approvals/ApprovedTests.SampleClassWithDisabledInjectJetBrainsAnnotations.approved.txt
+++ b/Tests/approvals/ApprovedTests.SampleClassWithDisabledInjectJetBrainsAnnotations.approved.txt
@@ -1,0 +1,267 @@
+﻿.class public auto ansi beforefieldinit SampleClassWithDisabledInjectJetBrainsAnnotations
+       extends [mscorlib]System.Object
+{
+  .class auto ansi sealed nested private beforefieldinit '<SomeAsyncMethod>d__1'
+         extends [mscorlib]System.ValueType
+         implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field public int32 '<>1__state'
+    .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
+    .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter '<>u__1'
+    .method private hidebysig newslot virtual final 
+            instance void  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+      // Code size       194 (0xc2)
+      .maxstack  4
+      .locals init ([0] int32 ,
+               [1] string V_1,
+               [2] valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter V_2,
+               [3] class [mscorlib]System.Exception V_3)
+      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+      IL_0006:  stloc.0
+      .try
+      {
+        IL_0007:  ldloc.0
+        IL_0008:  brfalse.s  IL_0042
+        IL_000a:  ldc.i4.0
+        IL_000b:  call       class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Threading.Tasks.Task::Delay(int32)
+        IL_0010:  callvirt   instance valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter [mscorlib]System.Threading.Tasks.Task::GetAwaiter()
+        IL_0015:  stloc.2
+        IL_0016:  ldloca.s   V_2
+        IL_0018:  call       instance bool [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::get_IsCompleted()
+        IL_001d:  brtrue.s   IL_005e
+        IL_001f:  ldarg.0
+        IL_0020:  ldc.i4.0
+        IL_0021:  dup
+        IL_0022:  stloc.0
+        IL_0023:  stfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+        IL_0028:  ldarg.0
+        IL_0029:  ldloc.2
+        IL_002a:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>u__1'
+        IL_002f:  ldarg.0
+        IL_0030:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+        IL_0035:  ldloca.s   V_2
+        IL_0037:  ldarg.0
+        IL_0038:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter,valuetype SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'>(!!0&,
+                                                                                                                                                                                                                                                                                                             !!1&)
+        IL_003d:  leave      IL_00c1
+        IL_0042:  ldarg.0
+        IL_0043:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>u__1'
+        IL_0048:  stloc.2
+        IL_0049:  ldarg.0
+        IL_004a:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>u__1'
+        IL_004f:  initobj    [mscorlib]System.Runtime.CompilerServices.TaskAwaiter
+        IL_0055:  ldarg.0
+        IL_0056:  ldc.i4.m1
+        IL_0057:  dup
+        IL_0058:  stloc.0
+        IL_0059:  stfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+        IL_005e:  ldloca.s   V_2
+        IL_0060:  call       instance void [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::GetResult()
+        IL_0065:  ldloca.s   V_2
+        IL_0067:  initobj    [mscorlib]System.Runtime.CompilerServices.TaskAwaiter
+        IL_006d:  ldnull
+        IL_006e:  stloc.1
+        IL_006f:  leave.s    IL_0088
+      }  // end .try
+      catch [mscorlib]System.Exception 
+      {
+        IL_0071:  stloc.3
+        IL_0072:  ldarg.0
+        IL_0073:  ldc.i4.s   -2
+        IL_0075:  stfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+        IL_007a:  ldarg.0
+        IL_007b:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+        IL_0080:  ldloc.3
+        IL_0081:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetException(class [mscorlib]System.Exception)
+        IL_0086:  leave.s    IL_00c1
+      }  // end handler
+      IL_0088:  ldarg.0
+      IL_0089:  ldc.i4.s   -2
+      IL_008b:  stfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+      IL_0090:  ldarg.0
+      IL_0091:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+      IL_0096:  ldloc.1
+      IL_0097:  dup
+      IL_0098:  ldnull
+      IL_0099:  ceq
+      IL_009b:  ldc.i4.0
+      IL_009c:  ceq
+      IL_009e:  ldstr      "[NullGuard] Return value of method 'System.Threadi"
+      + "ng.Tasks.Task`1<System.String> SampleClassWithDisabledInjectJetBrainsAn"
+      + "notations::SomeAsyncMethod()' is null."
+      IL_00a3:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                         string)
+      IL_00a8:  dup
+      IL_00a9:  brtrue.s   IL_00bc
+      IL_00ab:  pop
+      IL_00ac:  ldstr      "[NullGuard] Return value of method 'System.Threadi"
+      + "ng.Tasks.Task`1<System.String> SampleClassWithDisabledInjectJetBrainsAn"
+      + "notations::SomeAsyncMethod()' is null."
+      IL_00b1:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_00b6:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetException(class [mscorlib]System.Exception)
+      IL_00bb:  ret
+      IL_00bc:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetResult(!0)
+      IL_00c1:  ret
+    } // end of method '<SomeAsyncMethod>d__1'::MoveNext
+    .method private hidebysig newslot virtual final 
+            instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+    {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+      IL_0006:  ldarg.1
+      IL_0007:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+      IL_000c:  ret
+    } // end of method '<SomeAsyncMethod>d__1'::SetStateMachine
+  } 
+  .field private string '<SomeProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig instance string 
+          SomeMethod(string nonNullArg) cil managed
+  {
+    // Code size       70 (0x46)
+    .maxstack  3
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "nonNullArg"
+    IL_0019:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldnull
+    IL_0025:  dup
+    IL_0026:  ldnull
+    IL_0027:  ceq
+    IL_0029:  ldc.i4.0
+    IL_002a:  ceq
+    IL_002c:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SampleClassWithDisabledInjectJetBrainsAnnotations::SomeMethod(System.St"
+    + "ring)' is null."
+    IL_0031:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0036:  dup
+    IL_0037:  brtrue.s   IL_0045
+    IL_0039:  pop
+    IL_003a:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SampleClassWithDisabledInjectJetBrainsAnnotations::SomeMethod(System.St"
+    + "ring)' is null."
+    IL_003f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0044:  throw
+    IL_0045:  ret
+  } 
+  .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
+          SomeAsyncMethod() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 47 53 61 6D 70 6C 65 43 6C 61 73 73 57 69   // ..GSampleClassWi
+                                                                                                                                       74 68 44 69 73 61 62 6C 65 64 49 6E 6A 65 63 74   // thDisabledInject
+                                                                                                                                       4A 65 74 42 72 61 69 6E 73 41 6E 6E 6F 74 61 74   // JetBrainsAnnotat
+                                                                                                                                       69 6F 6E 73 2B 3C 53 6F 6D 65 41 73 79 6E 63 4D   // ions+<SomeAsyncM
+                                                                                                                                       65 74 68 6F 64 3E 64 5F 5F 31 00 00 )             // ethod>d__1..
+    // Code size       49 (0x31)
+    .maxstack  2
+    .locals init (valuetype SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1' V_0,
+             valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Create()
+    IL_0007:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+    IL_000c:  ldloca.s   V_0
+    IL_000e:  ldc.i4.m1
+    IL_000f:  stfld      int32 SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>1__state'
+    IL_0014:  ldloc.0
+    IL_0015:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+    IL_001a:  stloc.1
+    IL_001b:  ldloca.s   V_1
+    IL_001d:  ldloca.s   V_0
+    IL_001f:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Start<valuetype SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'>(!!0&)
+    IL_0024:  ldloca.s   V_0
+    IL_0026:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SampleClassWithDisabledInjectJetBrainsAnnotations/'<SomeAsyncMethod>d__1'::'<>t__builder'
+    IL_002b:  call       instance class [mscorlib]System.Threading.Tasks.Task`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::get_Task()
+    IL_0030:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_SomeProperty() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       39 (0x27)
+    .maxstack  3
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SampleClassWithDisabledInjectJetBrainsAnnotations::'<SomeProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  ldnull
+    IL_0008:  ceq
+    IL_000a:  ldc.i4.0
+    IL_000b:  ceq
+    IL_000d:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SampleClassWithDisabledInjectJetBrainsAnnotations::SomeProperty()' is"
+    + " null."
+    IL_0012:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0017:  dup
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  pop
+    IL_001b:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SampleClassWithDisabledInjectJetBrainsAnnotations::SomeProperty()' is"
+    + " null."
+    IL_0020:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0025:  throw
+    IL_0026:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_SomeProperty(string 'value') cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       44 (0x2c)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SampleClassWithDisabledInjectJetBrainsAnnotations::SomeProper"
+    + "ty()' to null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "value"
+    IL_0019:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SampleClassWithDisabledInjectJetBrainsAnnotations::SomeProper"
+    + "ty()' to null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  stfld      string SampleClassWithDisabledInjectJetBrainsAnnotations::'<SomeProperty>k__BackingField'
+    IL_002b:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string SomeProperty()
+  {
+  } 
+}

--- a/Tests/approvals/ApprovedTests.SampleClassWithoutJetBrainsAnnotationsAttribute.approved.txt
+++ b/Tests/approvals/ApprovedTests.SampleClassWithoutJetBrainsAnnotationsAttribute.approved.txt
@@ -1,0 +1,118 @@
+﻿.class public auto ansi beforefieldinit SampleClassWithoutJetBrainsAnnotationsAttribute
+       extends [mscorlib]System.Object
+{
+  .field private string '<SomeProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig instance string 
+          SomeMethod(string nonNullArg) cil managed
+  {
+    // Code size       70 (0x46)
+    .maxstack  3
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "nonNullArg"
+    IL_0019:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldnull
+    IL_0025:  dup
+    IL_0026:  ldnull
+    IL_0027:  ceq
+    IL_0029:  ldc.i4.0
+    IL_002a:  ceq
+    IL_002c:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SampleClassWithoutJetBrainsAnnotationsAttribute::SomeMethod(System.Stri"
+    + "ng)' is null."
+    IL_0031:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0036:  dup
+    IL_0037:  brtrue.s   IL_0045
+    IL_0039:  pop
+    IL_003a:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SampleClassWithoutJetBrainsAnnotationsAttribute::SomeMethod(System.Stri"
+    + "ng)' is null."
+    IL_003f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0044:  throw
+    IL_0045:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_SomeProperty() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       39 (0x27)
+    .maxstack  3
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SampleClassWithoutJetBrainsAnnotationsAttribute::'<SomeProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  ldnull
+    IL_0008:  ceq
+    IL_000a:  ldc.i4.0
+    IL_000b:  ceq
+    IL_000d:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SampleClassWithoutJetBrainsAnnotationsAttribute::SomeProperty()' is n"
+    + "ull."
+    IL_0012:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0017:  dup
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  pop
+    IL_001b:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SampleClassWithoutJetBrainsAnnotationsAttribute::SomeProperty()' is n"
+    + "ull."
+    IL_0020:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0025:  throw
+    IL_0026:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_SomeProperty(string 'value') cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       44 (0x2c)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SampleClassWithoutJetBrainsAnnotationsAttribute::SomeProperty"
+    + "()' to null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "value"
+    IL_0019:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SampleClassWithoutJetBrainsAnnotationsAttribute::SomeProperty"
+    + "()' to null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  stfld      string SampleClassWithoutJetBrainsAnnotationsAttribute::'<SomeProperty>k__BackingField'
+    IL_002b:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string SomeProperty()
+  {
+  } 
+}

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -11,6 +11,8 @@
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private string '<PropertyWithNotNullAnnotation>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -24,6 +26,8 @@
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor([out] string& nonNullOutArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       43 (0x2b)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -52,6 +56,8 @@
           instance void  .ctor(string nonNullArg,
                                string nullArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       60 (0x3c)
     .maxstack  3
     IL_0000:  ldarg.1
@@ -84,6 +90,8 @@
           SomeMethod(string nonNullArg,
                      string nullArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       43 (0x2b)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -281,6 +289,7 @@
   .method public hidebysig instance string 
           MethodWithReturnValue(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       75 (0x4b)
     .maxstack  3
     IL_0000:  ldarg.1
@@ -325,6 +334,8 @@
   .method public hidebysig instance void 
           MethodWithRef(object& returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       39 (0x27)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -349,6 +360,8 @@
   .method public hidebysig instance void 
           MethodWithGeneric<T>(!!T returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       47 (0x2f)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -373,6 +386,8 @@
   .method public hidebysig instance void 
           MethodWithGenericRef<T>(!!T& returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       57 (0x39)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -407,7 +422,7 @@
   .method public hidebysig instance string 
           MethodWithCanBeNullResult() cil managed
   {
-    .custom instance void CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       2 (0x2)
     .maxstack  1
     IL_0000:  ldnull
@@ -416,6 +431,8 @@
   .method public hidebysig instance void 
           MethodWithOutValue([out] string& nonNullOutArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -471,6 +488,10 @@
           MethodWithTwoRefs(string& first,
                             string& second) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [2]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       77 (0x4d)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -513,6 +534,10 @@
           MethodWithTwoOuts([out] string& first,
                             [out] string& second) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [2]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       73 (0x49)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -565,6 +590,7 @@
           MethodWithOptionalParameterWithNonNullDefaultValue([opt] string optional) cil managed
   {
     .param [1] = "default"
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -595,6 +621,8 @@
   .method public hidebysig instance void 
           MethodWithGenericOut<T>([out] !!T& item) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       59 (0x3b)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -620,6 +648,7 @@
   } 
   .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       103 (0x67)
     .maxstack  3
     .locals init ([0] !!T )
@@ -671,6 +700,9 @@
   .method public hidebysig instance object 
           MethodWithOutAndReturn([out] string& prefix) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       70 (0x46)
     .maxstack  3
     IL_0000:  ldarg.1
@@ -713,6 +745,8 @@
   .method public hidebysig instance void 
           MethodWithExistingArgumentGuard(string x) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       67 (0x43)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -774,8 +808,105 @@
     IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
     IL_001e:  ret
   } 
+  .method public hidebysig instance string 
+          MethodWithNotNullAnnotations(string nonNullArg) cil managed
+  {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       70 (0x46)
+    .maxstack  3
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "nonNullArg"
+    IL_0019:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldnull
+    IL_0025:  dup
+    IL_0026:  ldnull
+    IL_0027:  ceq
+    IL_0029:  ldc.i4.0
+    IL_002a:  ceq
+    IL_002c:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithNotNullAnnotations(System.String)' is null."
+    IL_0031:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0036:  dup
+    IL_0037:  brtrue.s   IL_0045
+    IL_0039:  pop
+    IL_003a:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithNotNullAnnotations(System.String)' is null."
+    IL_003f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0044:  throw
+    IL_0045:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyWithNotNullAnnotation() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       39 (0x27)
+    .maxstack  3
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyWithNotNullAnnotation>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  ldnull
+    IL_0008:  ceq
+    IL_000a:  ldc.i4.0
+    IL_000b:  ceq
+    IL_000d:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::PropertyWithNotNullAnnotation()' is null."
+    IL_0012:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0017:  dup
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  pop
+    IL_001b:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::PropertyWithNotNullAnnotation()' is null."
+    IL_0020:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0025:  throw
+    IL_0026:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyWithNotNullAnnotation(string 'value') cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       44 (0x2c)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  ceq
+    IL_0004:  ldc.i4.0
+    IL_0005:  ceq
+    IL_0007:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::PropertyWithNotNullAnnotation()' to null."
+    IL_000c:  call       void [System]System.Diagnostics.Debug::Assert(bool,
+                                                                       string)
+    IL_0011:  ldarg.1
+    IL_0012:  brtrue.s   IL_0024
+    IL_0014:  ldstr      "value"
+    IL_0019:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::PropertyWithNotNullAnnotation()' to null."
+    IL_001e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0023:  throw
+    IL_0024:  ldarg.0
+    IL_0025:  ldarg.1
+    IL_0026:  stfld      string SimpleClass::'<PropertyWithNotNullAnnotation>k__BackingField'
+    IL_002b:  ret
+  } 
   .property instance string NonNullProperty()
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
   .property instance string NullProperty()
   {
@@ -789,5 +920,9 @@
   .property instance valuetype [mscorlib]System.Nullable`1<int32>
           NonNullNullableProperty()
   {
+  } 
+  .property instance string PropertyWithNotNullAnnotation()
+  {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
 }

--- a/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClass.approved.txt
@@ -2,10 +2,15 @@
        extends [mscorlib]System.Object
 {
   .field private string '<NonNullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<NullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -103,6 +108,7 @@
   .method public hidebysig specialname instance string 
           get_NonNullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       39 (0x27)
     .maxstack  3
     IL_0000:  ldarg.0
@@ -128,6 +134,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       44 (0x2c)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -155,6 +162,7 @@
   .method public hidebysig specialname instance string 
           get_NullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -164,6 +172,7 @@
   .method public hidebysig specialname instance void 
           set_NullProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -174,6 +183,7 @@
   .method public hidebysig specialname instance string 
           get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
@@ -183,6 +193,7 @@
   .method public hidebysig specialname instance void 
           set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       44 (0x2c)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -212,6 +223,7 @@
   .method public hidebysig specialname instance string 
           get_PropertyAllowsNullSetButDoesNotAllowNullGet() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       39 (0x27)
     .maxstack  3
     IL_0000:  ldarg.0
@@ -237,6 +249,7 @@
   .method public hidebysig specialname instance void 
           set_PropertyAllowsNullSetButDoesNotAllowNullGet(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -247,6 +260,7 @@
   .method public hidebysig specialname instance valuetype [mscorlib]System.Nullable`1<int32> 
           get_NonNullNullableProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -256,6 +270,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullNullableProperty(valuetype [mscorlib]System.Nullable`1<int32> 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -2,10 +2,15 @@
        extends [mscorlib]System.Object
 {
   .field private string '<NonNullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<NullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private string '<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -78,6 +83,7 @@
   .method public hidebysig specialname instance string 
           get_NonNullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -94,6 +100,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       27 (0x1b)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -112,6 +119,7 @@
   .method public hidebysig specialname instance string 
           get_NullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -121,6 +129,7 @@
   .method public hidebysig specialname instance void 
           set_NullProperty(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -131,6 +140,7 @@
   .method public hidebysig specialname instance string 
           get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
@@ -140,6 +150,7 @@
   .method public hidebysig specialname instance void 
           set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       27 (0x1b)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -159,6 +170,7 @@
   .method public hidebysig specialname instance string 
           get_PropertyAllowsNullSetButDoesNotAllowNullGet() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -175,6 +187,7 @@
   .method public hidebysig specialname instance void 
           set_PropertyAllowsNullSetButDoesNotAllowNullGet(string 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -185,6 +198,7 @@
   .method public hidebysig specialname instance valuetype [mscorlib]System.Nullable`1<int32> 
           get_NonNullNullableProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -194,6 +208,7 @@
   .method public hidebysig specialname instance void 
           set_NonNullNullableProperty(valuetype [mscorlib]System.Nullable`1<int32> 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0

--- a/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -11,6 +11,8 @@
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private string '<PropertyWithNotNullAnnotation>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -24,6 +26,8 @@
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor([out] string& nonNullOutArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       25 (0x19)
     .maxstack  2
     IL_0000:  ldarg.0
@@ -43,6 +47,8 @@
           instance void  .ctor(string nonNullArg,
                                string nullArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       43 (0x2b)
     .maxstack  3
     IL_0000:  ldarg.1
@@ -67,6 +73,8 @@
           SomeMethod(string nonNullArg,
                      string nullArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       26 (0x1a)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -219,6 +227,7 @@
   .method public hidebysig instance string 
           MethodWithReturnValue(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       41 (0x29)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -245,6 +254,8 @@
   .method public hidebysig instance void 
           MethodWithRef(object& returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       21 (0x15)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -260,6 +271,8 @@
   .method public hidebysig instance void 
           MethodWithGeneric<T>(!!T returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       25 (0x19)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -275,6 +288,8 @@
   .method public hidebysig instance void 
           MethodWithGenericRef<T>(!!T& returnNull) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       30 (0x1e)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -299,7 +314,7 @@
   .method public hidebysig instance string 
           MethodWithCanBeNullResult() cil managed
   {
-    .custom instance void CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.CanBeNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       2 (0x2)
     .maxstack  1
     IL_0000:  ldnull
@@ -308,6 +323,8 @@
   .method public hidebysig instance void 
           MethodWithOutValue([out] string& nonNullOutArg) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       19 (0x13)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -354,6 +371,10 @@
           MethodWithTwoRefs(string& first,
                             string& second) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [2]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       41 (0x29)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -378,6 +399,10 @@
           MethodWithTwoOuts([out] string& first,
                             [out] string& second) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [2]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -412,6 +437,7 @@
           MethodWithOptionalParameterWithNonNullDefaultValue([opt] string optional) cil managed
   {
     .param [1] = "default"
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -434,6 +460,8 @@
   .method public hidebysig instance void 
           MethodWithGenericOut<T>([out] !!T& item) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       32 (0x20)
     .maxstack  1
     IL_0000:  ldarg.1
@@ -449,6 +477,7 @@
   } 
   .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       59 (0x3b)
     .maxstack  2
     .locals init ([0] !!T )
@@ -480,6 +509,9 @@
   .method public hidebysig instance object 
           MethodWithOutAndReturn([out] string& prefix) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       35 (0x23)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -504,6 +536,8 @@
   .method public hidebysig instance void 
           MethodWithExistingArgumentGuard(string x) cil managed
   {
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       50 (0x32)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -557,8 +591,70 @@
     IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
     IL_001e:  ret
   } 
+  .method public hidebysig instance string 
+          MethodWithNotNullAnnotations(string nonNullArg) cil managed
+  {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       36 (0x24)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldnull
+    IL_0014:  dup
+    IL_0015:  brtrue.s   IL_0023
+    IL_0017:  pop
+    IL_0018:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithNotNullAnnotations(System.String)' is null."
+    IL_001d:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0022:  throw
+    IL_0023:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyWithNotNullAnnotation() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyWithNotNullAnnotation>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::PropertyWithNotNullAnnotation()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyWithNotNullAnnotation(string 'value') cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::PropertyWithNotNullAnnotation()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string SimpleClass::'<PropertyWithNotNullAnnotation>k__BackingField'
+    IL_001a:  ret
+  } 
   .property instance string NonNullProperty()
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
   .property instance string NullProperty()
   {
@@ -572,5 +668,9 @@
   .property instance valuetype [mscorlib]System.Nullable`1<int32>
           NonNullNullableProperty()
   {
+  } 
+  .property instance string PropertyWithNotNullAnnotation()
+  {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
   } 
 }

--- a/Tests/approvals/ApprovedTests.SpecialClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SpecialClass.approved.txt
@@ -9,6 +9,7 @@
                     [mscorlib]System.IDisposable,
                     [mscorlib]System.Collections.IEnumerator
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field private int32 '<>1__state'
     .field private int32 '<>2__current'
     .field private int32 '<>l__initialThreadId'
@@ -18,6 +19,7 @@
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor(int32 '<>1__state') cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       25 (0x19)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -33,6 +35,7 @@
     .method private hidebysig newslot virtual final 
             instance void  System.IDisposable.Dispose() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.IDisposable::Dispose
       // Code size       1 (0x1)
       .maxstack  8
@@ -95,6 +98,7 @@
     .method private hidebysig newslot specialname virtual final 
             instance int32  'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override  method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
       // Code size       7 (0x7)
       .maxstack  8
@@ -105,6 +109,7 @@
     .method private hidebysig newslot virtual final 
             instance void  System.Collections.IEnumerator.Reset() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerator::Reset
       // Code size       6 (0x6)
       .maxstack  8
@@ -114,6 +119,7 @@
     .method private hidebysig newslot specialname virtual final 
             instance object  System.Collections.IEnumerator.get_Current() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerator::get_Current
       // Code size       12 (0xc)
       .maxstack  8
@@ -126,6 +132,7 @@
             instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 
             'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override  method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
       // Code size       55 (0x37)
       .maxstack  2
@@ -158,6 +165,7 @@
             instance class [mscorlib]System.Collections.IEnumerator 
             System.Collections.IEnumerable.GetEnumerator() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerable::GetEnumerator
       // Code size       7 (0x7)
       .maxstack  8
@@ -177,6 +185,7 @@
   .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass1_0'
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public string nonNullArg
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -202,6 +211,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
     .field public string nonNullArg
@@ -291,6 +301,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -304,6 +315,7 @@
   .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass2_0'
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public bool returnNull
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -332,6 +344,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
     .field public bool returnNull
@@ -443,6 +456,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -457,6 +471,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
     .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter '<>u__1'
@@ -542,6 +557,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -556,6 +572,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
     .method private hidebysig newslot virtual final 
@@ -596,6 +613,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -609,6 +627,7 @@
   .method public hidebysig instance class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> 
           CountTo(int32 end) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1A 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                           3C 43 6F 75 6E 74 54 6F 3E 64 5F 5F 30 00 00 )    // <CountTo>d__0..
     // Code size       15 (0xf)
     .maxstack  3
@@ -623,6 +642,7 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 31 00 00 )                            // >d__1..
     // Code size       93 (0x5d)
@@ -667,6 +687,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 32   // nValueAsync>d__2
                                                                                                                                        00 00 ) 
@@ -697,6 +718,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodAllowsNullReturnValueAsync() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 33 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..3SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 41 6C 6C 6F 77 73 4E 75 6C   // <MethodAllowsNul
                                                                                                                                        6C 52 65 74 75 72 6E 56 61 6C 75 65 41 73 79 6E   // lReturnValueAsyn
                                                                                                                                        63 3E 64 5F 5F 33 00 00 )                         // c>d__3..
@@ -724,6 +746,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<int32> 
           NoAwaitCode() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1E 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                        3C 4E 6F 41 77 61 69 74 43 6F 64 65 3E 64 5F 5F   // <NoAwaitCode>d__
                                                                                                                                        34 00 00 )                                        // 4..
     // Code size       49 (0x31)

--- a/Tests/approvals/ApprovedTests.SpecialClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.SpecialClass.approved.txt
@@ -642,9 +642,12 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.ItemNotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 31 00 00 )                            // >d__1..
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       93 (0x5d)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<SomeMethodAsync>d__1' V_0,
@@ -687,6 +690,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.ItemNotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 32   // nValueAsync>d__2

--- a/Tests/approvals/ApprovedTests.SpecialClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SpecialClassNoAssert.approved.txt
@@ -632,9 +632,12 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.ItemNotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 31 00 00 )                            // >d__1..
+    .param [1]
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.NotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       76 (0x4c)
     .maxstack  2
     .locals init (valuetype SpecialClass/'<SomeMethodAsync>d__1' V_0,
@@ -669,6 +672,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [JetBrains.Annotations]JetBrains.Annotations.ItemNotNullAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 32   // nValueAsync>d__2

--- a/Tests/approvals/ApprovedTests.SpecialClassNoAssert.approved.txt
+++ b/Tests/approvals/ApprovedTests.SpecialClassNoAssert.approved.txt
@@ -9,6 +9,7 @@
                     [mscorlib]System.IDisposable,
                     [mscorlib]System.Collections.IEnumerator
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field private int32 '<>1__state'
     .field private int32 '<>2__current'
     .field private int32 '<>l__initialThreadId'
@@ -18,6 +19,7 @@
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor(int32 '<>1__state') cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       25 (0x19)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -33,6 +35,7 @@
     .method private hidebysig newslot virtual final 
             instance void  System.IDisposable.Dispose() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.IDisposable::Dispose
       // Code size       1 (0x1)
       .maxstack  8
@@ -95,6 +98,7 @@
     .method private hidebysig newslot specialname virtual final 
             instance int32  'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override  method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
       // Code size       7 (0x7)
       .maxstack  8
@@ -105,6 +109,7 @@
     .method private hidebysig newslot virtual final 
             instance void  System.Collections.IEnumerator.Reset() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerator::Reset
       // Code size       6 (0x6)
       .maxstack  8
@@ -114,6 +119,7 @@
     .method private hidebysig newslot specialname virtual final 
             instance object  System.Collections.IEnumerator.get_Current() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerator::get_Current
       // Code size       12 (0xc)
       .maxstack  8
@@ -126,6 +132,7 @@
             instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 
             'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override  method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
       // Code size       55 (0x37)
       .maxstack  2
@@ -158,6 +165,7 @@
             instance class [mscorlib]System.Collections.IEnumerator 
             System.Collections.IEnumerable.GetEnumerator() cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Collections.IEnumerable::GetEnumerator
       // Code size       7 (0x7)
       .maxstack  8
@@ -177,6 +185,7 @@
   .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass1_0'
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public string nonNullArg
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -202,6 +211,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
     .field public string nonNullArg
@@ -291,6 +301,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -304,6 +315,7 @@
   .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass2_0'
          extends [mscorlib]System.Object
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public bool returnNull
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -332,6 +344,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
     .field public bool returnNull
@@ -433,6 +446,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -447,6 +461,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
     .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter '<>u__1'
@@ -532,6 +547,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -546,6 +562,7 @@
          extends [mscorlib]System.ValueType
          implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public int32 '<>1__state'
     .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
     .method private hidebysig newslot virtual final 
@@ -586,6 +603,7 @@
     .method private hidebysig newslot virtual final 
             instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
     {
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 ) 
       .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
       // Code size       13 (0xd)
       .maxstack  8
@@ -599,6 +617,7 @@
   .method public hidebysig instance class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> 
           CountTo(int32 end) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1A 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                           3C 43 6F 75 6E 74 54 6F 3E 64 5F 5F 30 00 00 )    // <CountTo>d__0..
     // Code size       15 (0xf)
     .maxstack  3
@@ -613,6 +632,7 @@
           SomeMethodAsync(string nonNullArg,
                           string nullArg) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 22 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // .."SpecialClass+
                                                                                                                                        3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
                                                                                                                                        3E 64 5F 5F 31 00 00 )                            // >d__1..
     // Code size       76 (0x4c)
@@ -649,6 +669,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodWithReturnValueAsync(bool returnNull) cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 2D 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..-SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
                                                                                                                                        6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 32   // nValueAsync>d__2
                                                                                                                                        00 00 ) 
@@ -679,6 +700,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
           MethodAllowsNullReturnValueAsync() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 33 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ..3SpecialClass+
                                                                                                                                        3C 4D 65 74 68 6F 64 41 6C 6C 6F 77 73 4E 75 6C   // <MethodAllowsNul
                                                                                                                                        6C 52 65 74 75 72 6E 56 61 6C 75 65 41 73 79 6E   // lReturnValueAsyn
                                                                                                                                        63 3E 64 5F 5F 33 00 00 )                         // c>d__3..
@@ -706,6 +728,7 @@
   .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<int32> 
           NoAwaitCode() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.AsyncStateMachineAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 1E 53 70 65 63 69 61 6C 43 6C 61 73 73 2B   // ...SpecialClass+
                                                                                                                                        3C 4E 6F 41 77 61 69 74 43 6F 64 65 3E 64 5F 5F   // <NoAwaitCode>d__
                                                                                                                                        34 00 00 )                                        // 4..
     // Code size       49 (0x31)

--- a/Tests/approvals/ApprovedTests.UnsafeClass.approved.txt
+++ b/Tests/approvals/ApprovedTests.UnsafeClass.approved.txt
@@ -2,6 +2,7 @@
        extends [mscorlib]System.Object
 {
   .field private int32* '<NullProperty>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig instance int32* 
           MethodWithAmp(int32* 'instance') cil managed
   {
@@ -15,6 +16,7 @@
   .method public hidebysig specialname instance int32* 
           get_NullProperty() cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -24,6 +26,7 @@
   .method public hidebysig specialname instance void 
           set_NullProperty(int32* 'value') cil managed
   {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       8 (0x8)
     .maxstack  8
     IL_0000:  ldarg.0


### PR DESCRIPTION
Implements feature request #54.

During implementing this PR, I mentioned that the [proposed option 2](https://github.com/Fody/NullGuard/issues/54#issuecomment-134158391) is a problem for rewritten libraries which already reference `JetBrains.Annotations` and use `ILMerge /internalize`. If _NullGuard_ would inject internal `NotNullAttribute` declarations, `ILMerge` would fail because of duplicated type declarations (respectively the `/allowDup` switch would rewrite the type names which would be ignored by R#).

Therefore I implemented option 1 (with a new `[InjectJetBrainsAnnotations]` configuration attribute). It's named "JetBrainsAnnotations" because the injected attributes are JetBrains.Annotations/ReSharper-specific in the following ways.
1. For method results, decorating the _method itself_ with `[NotNull]` instead of the return type.
2. Decorating `[ItemNotNull]` on `async` methods instead of `[NotNull]` (see [RSRP-376091](https://youtrack.jetbrains.com/issue/RSRP-376091#id_l.I.ic.it.c.c_27_1054764.comment_content_row_27_1054764)).
3. Decorating `[NotNull]` only for the whole property (ReSharper doesn't support `[return: NotNull]` or `[param: NotNull]` for property getters/setters).

@reviewers:
- It's probably easier to review the two commits separately because the first one has a lot of changes but only restores the removed custom attribute assertions in the tests, lost in commit 5f6673d1bc7d974ff9efb45dfee17d1b9a77a74d.
- I have two review questions (see REVIEW comments in `ModuleWeaver.cs` and `AssemblyWeaver.cs`).
