### PR TITLE
New "explicit" mode for null guards

### DIFF
--- a/AssemblyToProcessExplicit/AssemblyToProcessExplicit.csproj
+++ b/AssemblyToProcessExplicit/AssemblyToProcessExplicit.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3B149C17-711A-4D09-89DA-6BE5712DFE7B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AssemblyToProcessExplicit</RootNamespace>
+    <AssemblyName>AssemblyToProcessExplicit</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ReSharperAnnotations.cs" />
+    <Compile Include="ClassWithExplicitInterface.cs" />
+    <Compile Include="ClassWithPrivateMethod.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="GenericClass.cs" />
+    <Compile Include="SimpleClass.cs" />
+    <Compile Include="Indexers.cs" />
+    <Compile Include="SpecialClass.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj">
+      <Project>{B5AEB0E8-28F4-4955-A055-9C200F7113F0}</Project>
+      <Name>ReferenceAssembly</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/AssemblyToProcessExplicit/ClassWithExplicitInterface.cs
+++ b/AssemblyToProcessExplicit/ClassWithExplicitInterface.cs
@@ -1,0 +1,9 @@
+using System;
+
+public class ClassWithExplicitInterface : IComparable<string>
+{
+    int IComparable<string>.CompareTo([NotNull] string other)
+    {
+        return 0;
+    }
+}

--- a/AssemblyToProcessExplicit/ClassWithPrivateMethod.cs
+++ b/AssemblyToProcessExplicit/ClassWithPrivateMethod.cs
@@ -1,0 +1,19 @@
+using NullGuard;
+
+[NullGuard(ValidationFlags.NonPublic | ValidationFlags.Arguments)]
+public class ClassWithPrivateMethod
+{
+    public void PublicWrapperOfPrivateMethod()
+    {
+        SomePrivateMethod(null);
+    }
+
+    // ReSharper disable UnusedParameter.Local
+    void SomePrivateMethod([NotNull] string x)
+    // ReSharper restore UnusedParameter.Local
+    {
+    }
+
+    [NotNull]
+    public string SomeProperty { get; set; }
+}

--- a/AssemblyToProcessExplicit/GenericClass.cs
+++ b/AssemblyToProcessExplicit/GenericClass.cs
@@ -1,0 +1,5 @@
+public class GenericClass<T>
+{
+    [NotNull]
+    public T NonNullProperty { get; set; }
+}

--- a/AssemblyToProcessExplicit/Indexers.cs
+++ b/AssemblyToProcessExplicit/Indexers.cs
@@ -1,0 +1,29 @@
+using NullGuard;
+
+public class Indexers
+{
+    public class NonNullable
+    {
+        [NotNull]
+        public string this[[NotNull] string nonNullParam1, [NotNull] string nonNullParam2]
+        {
+            get { return "return value of NonNullable"; }
+            set { }
+        }
+    }
+
+    public class PassThroughGetterReturnValue
+    {
+        [NotNull]
+        public string this[string returnValue] => returnValue;
+    }
+
+    public class AllowedNulls
+    {
+        public string this[string allowNull, int? nullableInt, string optional = null]
+        {
+            get { return null; }
+            set { }
+        }
+    }
+}

--- a/AssemblyToProcessExplicit/ReSharperAnnotations.cs
+++ b/AssemblyToProcessExplicit/ReSharperAnnotations.cs
@@ -1,0 +1,21 @@
+using System;
+
+[AttributeUsage(
+    AttributeTargets.Method |
+    AttributeTargets.Property |
+    AttributeTargets.Field |
+    AttributeTargets.Parameter |
+    AttributeTargets.Delegate)]
+public sealed class CanBeNullAttribute : Attribute
+{
+}
+
+[AttributeUsage(
+    AttributeTargets.Method |
+    AttributeTargets.Property |
+    AttributeTargets.Field |
+    AttributeTargets.Parameter |
+    AttributeTargets.Delegate)]
+public sealed class NotNullAttribute : Attribute
+{
+}

--- a/AssemblyToProcessExplicit/SimpleClass.cs
+++ b/AssemblyToProcessExplicit/SimpleClass.cs
@@ -29,6 +29,12 @@ public class SimpleClass
     public string NullProperty { get; set; }
 
     [NotNull]
+    public string PropertyAllowsNullGetButDoesNotAllowNullSet { [return: AllowNull] get; set; }
+
+    [NotNull]
+    public string PropertyAllowsNullSetButDoesNotAllowNullGet { get; [param: AllowNull] set; }
+
+    [NotNull]
     public int? NonNullNullableProperty { get; set; }
 
     [NotNull]

--- a/AssemblyToProcessExplicit/SimpleClass.cs
+++ b/AssemblyToProcessExplicit/SimpleClass.cs
@@ -1,0 +1,210 @@
+using System;
+using NullGuard;
+
+public class SimpleClass
+{
+    public SimpleClass()
+    {
+    }
+
+    // Why would anyone place an out parameter on a ctor?! I don't know, but I'll support your idiocy.
+    public SimpleClass([NotNull] out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public SimpleClass([NotNull] string nonNullArg, [AllowNull] string nullArg)
+    {
+        Console.WriteLine(nonNullArg + " " + nullArg);
+    }
+
+    public void SomeMethod([NotNull] string nonNullArg, string nullArg)
+    {
+        Console.WriteLine(nonNullArg);
+    }
+
+    [NotNull]
+    public string NonNullProperty { get; set; }
+
+    public string NullProperty { get; set; }
+
+    [NotNull]
+    public int? NonNullNullableProperty { get; set; }
+
+    [NotNull]
+    public string MethodWithReturnValue(bool returnNull)
+    {
+        return returnNull ? null : "";
+    }
+
+    public void MethodWithRef([NotNull] ref object returnNull)
+    {
+    }
+
+    public void MethodWithGeneric<T>([NotNull] T returnNull)
+    {
+    }
+
+    public void MethodWithGenericRef<T>([NotNull] ref T returnNull)
+    {
+    }
+
+    public string MethodAllowsNullReturnValue()
+    {
+        return null;
+    }
+
+    public string MethodWithCanBeNullResult()
+    {
+        return null;
+    }
+
+    public void MethodWithOutValue([NotNull] out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public void MethodWithAllowedNullOutValue(out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public void PublicWrapperOfPrivateMethod()
+    {
+        SomePrivateMethod(null);
+    }
+
+    void SomePrivateMethod([NotNull] string x)
+    {
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithTwoRefs([NotNull] ref string first, [NotNull] ref string second)
+    {
+    }
+
+    public void MethodWithTwoOuts([NotNull] out string first, [NotNull] out string second)
+    {
+        first = null;
+        second = null;
+    }
+
+    public void MethodWithOptionalParameter([NotNull] string optional = null)
+    {
+    }
+
+    public void MethodWithOptionalParameterWithNonNullDefaultValue([NotNull] string optional = "default")
+    {
+    }
+
+    public void MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(string optional = "default")
+    {
+    }
+
+    public void MethodWithGenericOut<T>([NotNull] out T item)
+    {
+        item = default(T);
+    }
+
+    [NotNull]
+    public T MethodWithGenericReturn<T>(bool returnNull)
+    {
+        return returnNull ? default(T) : Activator.CreateInstance<T>();
+    }
+
+    [NotNull]
+    public object MethodWithOutAndReturn([NotNull] out string prefix)
+    {
+        prefix = null;
+        return null;
+    }
+
+    public void MethodWithExistingArgumentGuard([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentException("x is null or empty.", "x");
+
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithExistingArgumentNullGuard([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentNullException("x");
+
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithExistingArgumentNullGuardWithMessage([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentNullException("x", "x is null or empty.");
+
+        Console.WriteLine(x);
+    }
+
+    [NotNull]
+    public string ReturnValueChecksWithBranchToRetInstruction()
+    {
+        // This is a regression test scenario for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/57.
+
+        // It is important that the return value is assinged *before* the branch, otherwise the C# compiler emits
+        // instructions before the RET instructions, which wouldn't trigger the original issue.
+        string returnValue = null;
+
+        // The following, not-reachable, branch will jump directly to the RET statement (at least with Roslyn 1.0 with
+        // enabled optimizations flag) which triggers the issue (the return value checks will be skipped).
+        if ("".Length == 42)
+            throw new Exception("Not reachable");
+
+        return returnValue;
+    }
+
+    public void OutValueChecksWithBranchToRetInstruction([NotNull] out string outParam)
+    {
+        // This is the same scenario as above, but for out parameters.
+
+        outParam = null;
+
+        if ("".Length == 42)
+            throw new Exception("Not reachable");
+    }
+
+    [NotNull]
+    public string GetterReturnValueChecksWithBranchToRetInstruction
+    {
+        get
+        {
+            // This is the same scenario as above, but for property getters.
+
+            string returnValue = null;
+
+            if ("".Length == 42)
+                throw new Exception("Not reachable");
+
+            return returnValue;
+        }
+    }
+
+    public void OutValueChecksWithRetInstructionAsSwitchCase(int i, [NotNull] out string outParam)
+    {
+        // This is the same scenario as above, but with a SWITCH instruction with branch targets to RET
+        // instructions (they are handled specially).
+        // Note that its important to have more than sections to prove that all sections with only a RET instruction are handled.
+
+        outParam = null;
+        switch (i)
+        {
+            case 0:
+                return;
+            case 1:
+                Console.WriteLine("1");
+                break;
+            case 2:
+                return;
+            case 3:
+                Console.WriteLine("3");
+                break;
+        }
+    }
+}

--- a/AssemblyToProcessExplicit/SpecialClass.cs
+++ b/AssemblyToProcessExplicit/SpecialClass.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+#if (DEBUG)
+using System;
+using System.Threading.Tasks;
+using NullGuard;
+#endif
+
+public class SpecialClass
+{
+    [NotNull]
+    public IEnumerable<int> CountTo(int end)
+    {
+        for (var i = 0; i < end; i++)
+        {
+            yield return i;
+        }
+    }
+
+#if (DEBUG)
+
+    [NotNull]
+    public async Task SomeMethodAsync([NotNull] string nonNullArg, string nullArg)
+    {
+        await Task.Run(() => Console.WriteLine(nonNullArg));
+    }
+
+    [NotNull]
+    public async Task<string> MethodWithReturnValueAsync(bool returnNull)
+    {
+        return await Task.Run(() => returnNull ? null : "");
+    }
+
+    public async Task<string> MethodAllowsNullReturnValueAsync()
+    {
+        await Task.Delay(100);
+
+        return null;
+    }
+
+#pragma warning disable 1998
+
+    [NotNull]
+    public async Task<int> NoAwaitCode()
+    {
+        return 42;
+    }
+
+#pragma warning restore 1998
+#endif
+}

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -88,6 +88,7 @@
     <Compile Include="MethodProcessor.cs" />
     <Compile Include="ModuleWeaver.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs" />
+    <Compile Include="NullGuardMode.cs" />
     <Compile Include="PropertyProcessor.cs" />
     <Compile Include="ReferenceFinder.cs" />
     <Compile Include="WeavingException.cs" />

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -11,6 +11,7 @@ public class ModuleWeaver
     public XElement Config { get; set; }
     public ValidationFlags ValidationFlags { get; set; }
     public bool IncludeDebugAssert = true;
+    public bool ExplicitMode = false;
     public List<string> DefineConstants { get; set; }
     public Action<string> LogInfo { get; set; }
     public Action<string> LogWarn { get; set; }
@@ -77,6 +78,7 @@ public class ModuleWeaver
 
         ReadIncludeDebugAssert();
         ReadExcludeRegex();
+        ReadExplicitMode();
     }
 
     void ReadIncludeDebugAssert()
@@ -91,13 +93,25 @@ public class ModuleWeaver
         }
     }
 
+    void ReadExplicitMode()
+    {
+        var explicitModeAttribute = Config.Attribute("ExplicitMode");
+        if (explicitModeAttribute != null)
+        {
+            if (!bool.TryParse(explicitModeAttribute.Value, out ExplicitMode))
+            {
+                throw new WeavingException($"Could not parse 'ExplicitMode' from '{explicitModeAttribute.Value}'.");
+            }
+        }
+    }
+
     void ReadExcludeRegex()
     {
         var attribute = Config.Attribute("ExcludeRegex");
         var regex = attribute?.Value;
-        if(!string.IsNullOrWhiteSpace(regex))
-        { 
-            ExcludeRegex = new Regex(regex, RegexOptions.Compiled | RegexOptions.CultureInvariant); 
+        if (!string.IsNullOrWhiteSpace(regex))
+        {
+            ExcludeRegex = new Regex(regex, RegexOptions.Compiled | RegexOptions.CultureInvariant);
         }
     }
 
@@ -125,9 +139,10 @@ public class ModuleWeaver
     void ProcessAssembly(List<TypeDefinition> types)
     {
         var isDebug = IncludeDebugAssert && DefineConstants.Any(c => c == "DEBUG") && ReferenceFinder.DebugAssertMethod != null;
+        var explicitMode = ExplicitMode;
 
-        var methodProcessor = new MethodProcessor(ValidationFlags, isDebug);
-        var propertyProcessor = new PropertyProcessor(ValidationFlags, isDebug);
+        var methodProcessor = new MethodProcessor(ValidationFlags, isDebug, explicitMode);
+        var propertyProcessor = new PropertyProcessor(ValidationFlags, isDebug, explicitMode);
 
         foreach (var type in types)
         {

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -11,7 +11,7 @@ public class ModuleWeaver
     public XElement Config { get; set; }
     public ValidationFlags ValidationFlags { get; set; }
     public bool IncludeDebugAssert = true;
-    public bool ExplicitMode = false;
+    public NullGuardMode NullGuardMode;
     public List<string> DefineConstants { get; set; }
     public Action<string> LogInfo { get; set; }
     public Action<string> LogWarn { get; set; }
@@ -95,12 +95,12 @@ public class ModuleWeaver
 
     void ReadExplicitMode()
     {
-        var explicitModeAttribute = Config.Attribute("ExplicitMode");
-        if (explicitModeAttribute != null)
+        var modeAttribute = Config.Attribute("Mode");
+        if (modeAttribute != null)
         {
-            if (!bool.TryParse(explicitModeAttribute.Value, out ExplicitMode))
+            if (!Enum.TryParse(modeAttribute.Value, out NullGuardMode))
             {
-                throw new WeavingException($"Could not parse 'ExplicitMode' from '{explicitModeAttribute.Value}'.");
+                throw new WeavingException($"Could not parse 'NullGuardMode' from '{modeAttribute.Value}'.");
             }
         }
     }
@@ -139,7 +139,7 @@ public class ModuleWeaver
     void ProcessAssembly(List<TypeDefinition> types)
     {
         var isDebug = IncludeDebugAssert && DefineConstants.Any(c => c == "DEBUG") && ReferenceFinder.DebugAssertMethod != null;
-        var explicitMode = ExplicitMode;
+        var explicitMode = (NullGuardMode == NullGuardMode.Explicit);
 
         var methodProcessor = new MethodProcessor(ValidationFlags, isDebug, explicitMode);
         var propertyProcessor = new PropertyProcessor(ValidationFlags, isDebug, explicitMode);

--- a/Fody/NullGuardMode.cs
+++ b/Fody/NullGuardMode.cs
@@ -1,0 +1,11 @@
+﻿public enum NullGuardMode
+{
+    /// <summary>
+    /// Not null is implicit, allow null must be set explicit.
+    /// </summary>
+    Implicit,
+    /// <summary>
+    /// Not null must be set explicit, allow null is implicit.
+    /// </summary>
+    Explicit
+}

--- a/Fody/PropertyProcessor.cs
+++ b/Fody/PropertyProcessor.cs
@@ -66,9 +66,8 @@ public class PropertyProcessor
 
             getBody.SimplifyMacros();
 
-            if ((localValidationFlags.HasFlag(ValidationFlags.NonPublic) || (property.GetMethod.IsPublic && property.DeclaringType.IsPublicOrNestedPublic())) &&
-                (explicitMode || !property.GetMethod.MethodReturnType.AllowsNull(explicitMode))
-               )
+            if ((localValidationFlags.HasFlag(ValidationFlags.NonPublic) || (property.GetMethod.IsPublic && property.DeclaringType.IsPublicOrNestedPublic()))
+                && !property.GetMethod.MethodReturnType.AllowsNull(false))
             {
                 InjectPropertyGetterGuard(getBody, sequencePoint, property);
             }
@@ -142,7 +141,7 @@ public class PropertyProcessor
     {
         var valueParameter = property.SetMethod.GetPropertySetterValueParameter();
 
-        if (!explicitMode && !valueParameter.MayNotBeNull(explicitMode))
+        if (!valueParameter.MayNotBeNull(false))
             return;
 
         var guardInstructions = new List<Instruction>();

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion =  14.0.22823.1
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 14.0.22823.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fody", "Fody\Fody.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -19,42 +19,36 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceAssembly", "Refere
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessMono", "AssemblyToProcessMono\AssemblyToProcessMono.csproj", "{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessExplicit", "AssemblyToProcessExplicit\AssemblyToProcessExplicit.csproj", "{3B149C17-711A-4D09-89DA-6BE5712DFE7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|x86.ActiveCfg = Release|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|x86.ActiveCfg = Release|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A6D1B956-68D2-4D36-8AA0-24A88A40E4F2}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B149C17-711A-4D09-89DA-6BE5712DFE7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B149C17-711A-4D09-89DA-6BE5712DFE7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B149C17-711A-4D09-89DA-6BE5712DFE7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B149C17-711A-4D09-89DA-6BE5712DFE7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -21,6 +21,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessMono", "As
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyToProcessExplicit", "AssemblyToProcessExplicit\AssemblyToProcessExplicit.csproj", "{3B149C17-711A-4D09-89DA-6BE5712DFE7B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{974E133C-D426-43F6-BF9D-19CD0DBDFDE1}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You can also use RegEx to specify the name of a class to exclude from NullGuard.
     <NullGuard ExcludeRegex="^ClassToExclude$" />
 
 #### Explicit Mode
-If you are (already) using R#'s [NotNull] attribute in your code to explicitly annotate not null items, you may want
+If you are (already) using R#'s `[NotNull]` attribute in your code to explicitly annotate not null items, you may want
 to toggle the behavior to only add null guards for items that have an explicit not null annotation. 
 To get this behavior just enable the explicit mode in the FodyWeavers.xml:
 
@@ -231,7 +231,7 @@ This will toggle behavior like this:
         // Just the getter is not supported in explicit mode :-(
         public string NullPropertyOnGet { get; set; }
 
-
+You may use the `[NotNull]` attribute defined in JetBrains.Anntotations, or simply define your own.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -186,11 +186,59 @@ You can also use RegEx to specify the name of a class to exclude from NullGuard.
 
     <NullGuard ExcludeRegex="^ClassToExclude$" />
 
+#### Explicit Mode
+If you are (already) using R#'s [NotNull] attribute in your code to explicitly annotate not null items, you may want
+to toggle the behavior to only add null guards for items that have an explicit not null annotation. 
+To get this behavior just enable the explicit mode in the FodyWeavers.xml:
+
+    <NullGuard ExplicitMode="true" />
+
+This will toggle behavior like this:
+
+    public class Sample
+    {
+        public void SomeMethod([NotNull] string arg)
+        {
+            // throws ArgumentNullException if arg is null.
+        }
+
+        public void AnotherMethod(string arg)
+        {
+            // arg may be null here
+        }
+
+        [NotNull]
+        public string MethodWithReturn()
+        {
+            return SomeOtherClass.SomeMethod();
+        }
+
+        public string MethodAllowsNullReturnValue()
+        {
+            return null;
+        }
+
+        // Null checking works for automatic properties too.
+        // can only be applied to a whole property
+        [NotNull]
+        public string SomeProperty { get; set; }
+
+        // can be applied to a whole property
+        public string NullProperty { get; set; }
+
+        // Just the setter is not supported in explicit mode :-(
+        public string NullPropertyOnSet { get; set; }
+        // Just the getter is not supported in explicit mode :-(
+        public string NullPropertyOnGet { get; set; }
+
+
+
 ## Contributors
 
   * [Cameron MacFarland](https://github.com/distantcam)
   * [Simon Cropp](https://github.com/simoncropp)
   * [Tim Murphy](https://github.com/TimMurphy)
+  * [Tom Englert](https://github.com/tom-englert)
 
 ## Icon
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ https://nuget.org/packages/NullGuard.Fody/
 
         // Or just the setter.
         public string NullPropertyOnSet { get; [param: AllowNull] set; }
+
+        // Or just the getter.
+        public string NullPropertyOnGet { [return: AllowNull] get; set; }
     }
 
 ### What gets compiled 
@@ -219,17 +222,20 @@ This will toggle behavior like this:
         }
 
         // Null checking works for automatic properties too.
-        // can only be applied to a whole property
+        // Default in explicit mode is nullable
+        public string NullProperty { get; set; }
+
+        // NotNull can be applied to a whole property
         [NotNull]
         public string SomeProperty { get; set; }
 
-        // can be applied to a whole property
-        public string NullProperty { get; set; }
+        // or just the getter by overwriting the set method,
+        [NotNull]
+        public string NullPropertyOnSet { get; [param: AllowNull] set; }
 
-        // Just the setter is not supported in explicit mode :-(
-        public string NullPropertyOnSet { get; set; }
-        // Just the getter is not supported in explicit mode :-(
-        public string NullPropertyOnGet { get; set; }
+        // or just the setter.by overwriting the get method.
+        [NotNull]
+        public string NullPropertyOnGet { [return: AllowNull] get; set; }
 
 You may use the `[NotNull]` attribute defined in JetBrains.Anntotations, or simply define your own.
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ If you are (already) using R#'s `[NotNull]` attribute in your code to explicitly
 to toggle the behavior to only add null guards for items that have an explicit not null annotation. 
 To get this behavior just enable the explicit mode in the FodyWeavers.xml:
 
-    <NullGuard ExplicitMode="true" />
+    <NullGuard Mode="Explicit" />
 
-This will toggle behavior like this:
+This will toggle the behavior of null guards like this:
 
     public class Sample
     {

--- a/Tests/ApprovedTests.cs
+++ b/Tests/ApprovedTests.cs
@@ -14,85 +14,85 @@ public class ApprovedTests
     [Test]
     public void ClassWithBadAttributes()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "ClassWithBadAttributes"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "ClassWithBadAttributes"));
     }
 
     [Test]
     public void ClassWithPrivateMethod()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "ClassWithPrivateMethod"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "ClassWithPrivateMethod"));
     }
 
     [Test]
     public void ClassWithPrivateMethodNoAssert()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[1], "ClassWithPrivateMethod"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[1].Location, "ClassWithPrivateMethod"));
     }
 
     [Test]
     public void GenericClass()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "GenericClass`1"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "GenericClass`1"));
     }
 
     [Test]
     public void GenericClassNoAssert()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[1], "GenericClass`1"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[1].Location, "GenericClass`1"));
     }
 
     [Test]
     public void Indexers()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "Indexers"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "Indexers"));
     }
 
     [Test]
     public void InterfaceBadAttributes()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "InterfaceBadAttributes"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "InterfaceBadAttributes"));
     }
 
     [Test]
     public void SimpleClass()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "SimpleClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "SimpleClass"));
     }
 
     [Test]
     public void SimpleClassNoAssert()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[1], "SimpleClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[1].Location, "SimpleClass"));
     }
 
     [Test]
     public void SkipIXamlMetadataProvider()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "XamlMetadataProvider"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "XamlMetadataProvider"));
     }
 
     [Test]
     public void SpecialClass()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "SpecialClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "SpecialClass"));
     }
 
     [Test]
     public void SpecialClassNoAssert()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[1], "SpecialClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[1].Location, "SpecialClass"));
     }
 
     [Test]
     public void PublicNestedInsideNonPublic()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "NonPublicWithNested"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "NonPublicWithNested"));
     }
 
     [Test]
     public void UnsafeClass()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPaths[0], "UnsafeClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.Assemblies[0].Location, "UnsafeClass"));
     }
 
     [Test]

--- a/Tests/Helpers/AssemblyWeaver.cs
+++ b/Tests/Helpers/AssemblyWeaver.cs
@@ -122,7 +122,7 @@ public static class AssemblyWeaver
 
             var weavingTask = new ModuleWeaver
             {
-                Config = new XElement("NullGuard", new XAttribute("ExplicitMode", true)),
+                Config = new XElement("NullGuard", new XAttribute("Mode", "Explicit")),
                 ModuleDefinition = moduleDefinition,
                 AssemblyResolver = assemblyResolver,
                 DefineConstants = new List<string> { "DEBUG" } // Always testing the debug weaver

--- a/Tests/Helpers/AssemblyWeaver.cs
+++ b/Tests/Helpers/AssemblyWeaver.cs
@@ -47,7 +47,8 @@ public static class AssemblyWeaver
         Debug.Listeners.Clear();
         Debug.Listeners.Add(TestListener);
 
-        Directory.SetCurrentDirectory(Path.GetDirectoryName(typeof(AssemblyWeaver).Assembly.Location));
+        // Needed for local test run with NUnit 3.5
+        // Directory.SetCurrentDirectory(Path.GetDirectoryName(typeof(AssemblyWeaver).Assembly.Location));
 
         BeforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll");
         MonoBeforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcessMono\bin\Debug\AssemblyToProcessMono.dll");

--- a/Tests/Helpers/AssemblyWeaver.cs
+++ b/Tests/Helpers/AssemblyWeaver.cs
@@ -47,9 +47,6 @@ public static class AssemblyWeaver
         Debug.Listeners.Clear();
         Debug.Listeners.Add(TestListener);
 
-        // Needed for local test run with NUnit 3.5
-        // Directory.SetCurrentDirectory(Path.GetDirectoryName(typeof(AssemblyWeaver).Assembly.Location));
-
         BeforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll");
         MonoBeforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcessMono\bin\Debug\AssemblyToProcessMono.dll");
         var explicitBeforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcessExplicit\bin\Debug\AssemblyToProcessExplicit.dll");

--- a/Tests/RewritingConstructors.cs
+++ b/Tests/RewritingConstructors.cs
@@ -4,46 +4,46 @@ using NUnit.Framework;
 [TestFixture]
 public class RewritingConstructors
 {
-    Type sampleClassType;
+    private Func<int, Type> sampleClassType;
     Type classToExcludeType;
 
     [SetUp]
     public void SetUp()
     {
-        sampleClassType = AssemblyWeaver.Assemblies[0].GetType("SimpleClass");
+        sampleClassType = index => AssemblyWeaver.RewritingTestAssemblies[index].GetType("SimpleClass");
         classToExcludeType = AssemblyWeaver.Assemblies[1].GetType("ClassToExclude");
 
         AssemblyWeaver.TestListener.Reset();
     }
 
     [Test]
-    public void RequiresNonNullArgument()
+    public void RequiresNonNullArgument([Values(0, 1)] int index)
     {
-        Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType, null, "")),
+        Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType(index), null, "")),
             Throws.TargetInvocationException
                 .With.InnerException.TypeOf<ArgumentNullException>()
                 .And.InnerException.Property("ParamName").EqualTo("nonNullArg"));
     }
 
     [Test]
-    public void RequiresNonNullOutArgument()
+    public void RequiresNonNullOutArgument([Values(0, 1)] int index)
     {
         var args = new object[1];
-        Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType, args)),
+        Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType(index), args)),
             Throws.TargetInvocationException
                 .With.InnerException.TypeOf<InvalidOperationException>());
         Assert.AreEqual("Fail: [NullGuard] Out parameter 'nonNullOutArg' is null.", AssemblyWeaver.TestListener.Message);
     }
 
     [Test]
-    public void AllowsNullWhenAttributeApplied()
+    public void AllowsNullWhenAttributeApplied([Values(0, 1)] int index)
     {
-        Activator.CreateInstance(sampleClassType, "", null);
+        Activator.CreateInstance(sampleClassType(index), "", null);
     }
 
     [Test]
     public void AllowsNullWhenClassMatchExcludeRegex()
     {
-        Activator.CreateInstance(classToExcludeType, new object[]{ null });
+        Activator.CreateInstance(classToExcludeType, new object[] { null });
     }
 }

--- a/Tests/RewritingIndexers.cs
+++ b/Tests/RewritingIndexers.cs
@@ -4,38 +4,38 @@ using NUnit.Framework;
 [TestFixture]
 public class RewritingIndexers
 {
-    Type indexersClassType;
+    Func<int, Type> indexersClassType;
 
     [SetUp]
     public void SetUp()
     {
-        indexersClassType = AssemblyWeaver.Assemblies[0].GetType("Indexers");
+        indexersClassType = index => AssemblyWeaver.RewritingTestAssemblies[index].GetType("Indexers");
 
         AssemblyWeaver.TestListener.Reset();
     }
 
     [Test]
-    public void NonNullableIndexerSetterWithFirstArgumentNull()
+    public void NonNullableIndexerSetterWithFirstArgumentNull([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: null, nonNullParam2: null] = "value");
         Assert.AreEqual("nonNullParam1", exception.ParamName);
         Assert.AreEqual("Fail: [NullGuard] nonNullParam1 is null.", AssemblyWeaver.TestListener.Message);
     }
 
     [Test]
-    public void NonNullableIndexerSetterWithSecondArgumentNull()
+    public void NonNullableIndexerSetterWithSecondArgumentNull([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: null] = "value");
         Assert.AreEqual("nonNullParam2", exception.ParamName);
         Assert.AreEqual("Fail: [NullGuard] nonNullParam2 is null.", AssemblyWeaver.TestListener.Message);
     }
 
     [Test]
-    public void NonNullableIndexerSetterWithValueArgumentNull()
+    public void NonNullableIndexerSetterWithValueArgumentNull([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = null);
         Assert.AreEqual("value", exception.ParamName);
         Assert.AreEqual(
@@ -44,41 +44,41 @@ public class RewritingIndexers
     }
 
     [Test]
-    public void NonNullableIndexerSetterWithNonNullArguments()
+    public void NonNullableIndexerSetterWithNonNullArguments([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = "value";
     }
 
     [Test]
-    public void NonNullableIndexerGetterWithFirstArgumentNull()
+    public void NonNullableIndexerGetterWithFirstArgumentNull([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: null, nonNullParam2: null]));
         Assert.AreEqual("nonNullParam1", exception.ParamName);
         Assert.AreEqual("Fail: [NullGuard] nonNullParam1 is null.", AssemblyWeaver.TestListener.Message);
     }
 
     [Test]
-    public void NonNullableIndexerGetterWithSecondArgumentNull()
+    public void NonNullableIndexerGetterWithSecondArgumentNull([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: "arg 1", nonNullParam2: null]));
         Assert.AreEqual("nonNullParam2", exception.ParamName);
         Assert.AreEqual("Fail: [NullGuard] nonNullParam2 is null.", AssemblyWeaver.TestListener.Message);
     }
 
     [Test]
-    public void NonNullableIndexerGetterWithNonNullArguments()
+    public void NonNullableIndexerGetterWithNonNullArguments([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("NonNullable"));
         Assert.AreEqual("return value of NonNullable", instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"]);
     }
 
     [Test]
-    public void PassThroughGetterReturnValueWithNullArgument()
+    public void PassThroughGetterReturnValueWithNullArgument([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("PassThroughGetterReturnValue"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("PassThroughGetterReturnValue"));
         Assert.Throws<InvalidOperationException>(() => IgnoreValue(instance[returnValue: null]));
         Assert.AreEqual(
             "Fail: [NullGuard] Return value of property 'System.String Indexers/PassThroughGetterReturnValue::Item(System.String)' is null.",
@@ -86,23 +86,23 @@ public class RewritingIndexers
     }
 
     [Test]
-    public void PassThroughGetterReturnValueWithNonNullArgument()
+    public void PassThroughGetterReturnValueWithNonNullArgument([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("PassThroughGetterReturnValue"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("PassThroughGetterReturnValue"));
         Assert.AreEqual("not null", instance[returnValue: "not null"]);
     }
 
     [Test]
-    public void AllowedNullsIndexerSetter()
+    public void AllowedNullsIndexerSetter([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("AllowedNulls"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("AllowedNulls"));
         instance[allowNull: null, nullableInt: null] = null;
     }
 
     [Test]
-    public void AllowedNullsIndexerGetter()
+    public void AllowedNullsIndexerGetter([Values(0, 1)] int index)
     {
-        var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("AllowedNulls"));
+        var instance = (dynamic)Activator.CreateInstance(indexersClassType(index).GetNestedType("AllowedNulls"));
         Assert.AreEqual(null, instance[allowNull: null, nullableInt: null]);
     }
 

--- a/Tests/RewritingProperties.cs
+++ b/Tests/RewritingProperties.cs
@@ -59,7 +59,7 @@ public class RewritingProperties
     }
 
     [Test]
-    public void PropertyAllowsNullGetButNotSet([Values(0)] int index)
+    public void PropertyAllowsNullGetButNotSet([Values(0, 1)] int index)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType(index));
         Assert.Null(sample.PropertyAllowsNullGetButDoesNotAllowNullSet);
@@ -68,7 +68,7 @@ public class RewritingProperties
     }
 
     [Test]
-    public void PropertyAllowsNullSetButNotGet([Values(0)] int index)
+    public void PropertyAllowsNullSetButNotGet([Values(0, 1)] int index)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType(index));
         sample.PropertyAllowsNullSetButDoesNotAllowNullGet = null;

--- a/Tests/VerifyTest.cs
+++ b/Tests/VerifyTest.cs
@@ -8,19 +8,19 @@ public class VerifyTest
     [Test]
     public void PeVerify1()
     {
-        Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[0]);
+        Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.Assemblies[0].Location);
     }
 
     [Test]
     public void PeVerify2()
     {
-        Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[1]);
+        Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.Assemblies[1].Location);
     }
 
     [Test]
     public void PeVerify3()
     {
-        Verifier.Verify(AssemblyWeaver.MonoBeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[2]);
+        Verifier.Verify(AssemblyWeaver.MonoBeforeAssemblyPath, AssemblyWeaver.Assemblies[2].Location);
     }
 }
 


### PR DESCRIPTION
This adds the new functionality described in #67. Null guards are only added for items with an explicit [NotNull] attribute.

The changes in the program code are minimal, just added a flag to toggle between the modes and pass it to the "AllowsNull..()" extension methods.

The major change was to refactor the test code to make it extendable, so the tests can run for both cases, and to add a new test set with explicit annotations.

The default behavior does not change, the explicit mode must be activated via the configuration first.