### PR TITLE
A different approach to .NET Standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ __pycache__/
 *.xsd.cs
 
 # End of https://www.gitignore.io/api/visualstudio
+*.received.txt

--- a/AssemblyToProcessNetStandard/AssemblyToProcessNetStandard.csproj
+++ b/AssemblyToProcessNetStandard/AssemblyToProcessNetStandard.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyName>AssemblyToProcess</AssemblyName>
+    <RootNamespace>AssemblyToProcess</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AssemblyToProcess\ClassToExclude.cs" Link="ClassToExclude.cs" />
+    <Compile Include="..\AssemblyToProcess\ClassWithBadAttributes.cs" Link="ClassWithBadAttributes.cs" />
+    <Compile Include="..\AssemblyToProcess\ClassWithExplicitInterface.cs" Link="ClassWithExplicitInterface.cs" />
+    <Compile Include="..\AssemblyToProcess\ClassWithPrivateMethod.cs" Link="ClassWithPrivateMethod.cs" />
+    <Compile Include="..\AssemblyToProcess\GenericClass.cs" Link="GenericClass.cs" />
+    <Compile Include="..\AssemblyToProcess\Indexers.cs" Link="Indexers.cs" />
+    <Compile Include="..\AssemblyToProcess\InterfaceBadAttributes.cs" Link="InterfaceBadAttributes.cs" />
+    <Compile Include="..\AssemblyToProcess\IXamlMetadataProvider.cs" Link="IXamlMetadataProvider.cs" />
+    <Compile Include="..\AssemblyToProcess\NonPublicWithNested.cs" Link="NonPublicWithNested.cs" />
+    <Compile Include="..\AssemblyToProcess\ReSharperAnnotations.cs" Link="ReSharperAnnotations.cs" />
+    <Compile Include="..\AssemblyToProcess\Sample\Sample.cs" Link="Sample\Sample.cs" />
+    <Compile Include="..\AssemblyToProcess\Sample\SampleOutput.cs" Link="Sample\SampleOutput.cs" />
+    <Compile Include="..\AssemblyToProcess\Sample\SomeOtherClass.cs" Link="Sample\SomeOtherClass.cs" />
+    <Compile Include="..\AssemblyToProcess\SimpleClass.cs" Link="SimpleClass.cs" />
+    <Compile Include="..\AssemblyToProcess\SpecialClass.cs" Link="SpecialClass.cs" />
+    <Compile Include="..\AssemblyToProcess\UnsafeClass.cs" Link="UnsafeClass.cs" />
+    <Compile Include="..\AssemblyToProcess\XamlMetadataProvider.cs" Link="XamlMetadataProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Sample\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReferenceAssemblyNetStandard\RefernceAssemblyNetStandard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -97,6 +97,8 @@
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
     <MakeDir Directories="$(SolutionDir)NuGetBuild" />
+    <Exec Command="dotnet restore $(SolutionDir)NullGuard.NetStandard.sln"></Exec>
+    <Exec Command="dotnet build $(SolutionDir)NullGuard.NetStandard.sln"></Exec>
     <Copy SourceFiles="$(ProjectDir)NugetAssets\NullGuard.Fody.nuspec" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\install.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\install.ps1" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\uninstall.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\uninstall.ps1" />
@@ -106,6 +108,8 @@
     <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\NullGuard.xml" DestinationFolder="$(SolutionDir)NuGetBuild\Lib\portable-net4+sl5+wpa81+wp8+win8+MonoAndroid16+MonoTouch40" />
     <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\NullGuard.dll" DestinationFolder="$(SolutionDir)NuGetBuild\Lib\dotnet" />
     <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\NullGuard.xml" DestinationFolder="$(SolutionDir)NuGetBuild\Lib\dotnet" />
+    <Copy SourceFiles="$(SolutionDir)ReferenceAssemblyNetStandard\bin\$(ConfigurationName)\netstandard1.0\NullGuard.dll" DestinationFolder="$(SolutionDir)NuGetBuild\Lib\netstandard10" />
+    <Copy SourceFiles="$(SolutionDir)ReferenceAssemblyNetStandard\bin\$(ConfigurationName)\netstandard1.0\NullGuard.xml" DestinationFolder="$(SolutionDir)NuGetBuild\Lib\netstandard10" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(OutputPath)NullGuard.Fody.dll" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -98,7 +98,7 @@
     <Delete Files="@(FilesToDelete)" />
     <MakeDir Directories="$(SolutionDir)NuGetBuild" />
     <Exec Command="dotnet restore $(SolutionDir)NullGuard.NetStandard.sln"></Exec>
-    <Exec Command="dotnet build $(SolutionDir)NullGuard.NetStandard.sln"></Exec>
+    <Exec Command="dotnet build $(SolutionDir)NullGuard.NetStandard.sln -c $(ConfigurationName)"></Exec>
     <Copy SourceFiles="$(ProjectDir)NugetAssets\NullGuard.Fody.nuspec" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\install.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\install.ps1" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\uninstall.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\uninstall.ps1" />

--- a/NullGuard.NetStandard.sln
+++ b/NullGuard.NetStandard.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RefernceAssemblyNetStandard", "ReferenceAssemblyNetStandard\RefernceAssemblyNetStandard.csproj", "{A927A18D-21D3-4A1A-8D3C-A0B6AA7738E7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyToProcessNetStandard", "AssemblyToProcessNetStandard\AssemblyToProcessNetStandard.csproj", "{CB0393DD-3617-4F72-881F-23F18CCE8222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A927A18D-21D3-4A1A-8D3C-A0B6AA7738E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A927A18D-21D3-4A1A-8D3C-A0B6AA7738E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A927A18D-21D3-4A1A-8D3C-A0B6AA7738E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A927A18D-21D3-4A1A-8D3C-A0B6AA7738E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB0393DD-3617-4F72-881F-23F18CCE8222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB0393DD-3617-4F72-881F-23F18CCE8222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB0393DD-3617-4F72-881F-23F18CCE8222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB0393DD-3617-4F72-881F-23F18CCE8222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion =  14.0.22823.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 14.0.22823.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fody", "Fody\Fody.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/ReferenceAssemblyNetStandard/RefernceAssemblyNetStandard.csproj
+++ b/ReferenceAssemblyNetStandard/RefernceAssemblyNetStandard.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <AssemblyName>NullGuard</AssemblyName>
+    <RootNamespace>NullGuard</RootNamespace>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>False</DelaySign>
+    <GenerateAssemblyTitleAttribute>False</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyProductAttribute>False</GenerateAssemblyProductAttribute>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
+    <Compile Include="..\ReferenceAssembly\AllowNullAttribute.cs" Link="AllowNullAttribute.cs" />
+    <Compile Include="..\ReferenceAssembly\NullGuardAttribute.cs" Link="NullGuardAttribute.cs" />
+    <Compile Include="..\ReferenceAssembly\ValidationFlags.cs" Link="ValidationFlags.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Helpers/TestCaseHelper.cs
+++ b/Tests/Helpers/TestCaseHelper.cs
@@ -3,13 +3,27 @@ using NUnit.Framework;
 
 public static class TestCaseHelper
 {
-    public static IEnumerable<TestCaseData> GetWovenTypes(string typeName)
+    public static IEnumerable<TestCaseData> ClassWithExplicitInterfaceTypes => GetWovenTypes("ClassWithExplicitInterface");
+
+    public static IEnumerable<TestCaseData> SampleClassTypes => GetWovenTypes("SimpleClass");
+
+    public static IEnumerable<TestCaseData> SpecialClassTypes => GetWovenTypes("SpecialClass");
+
+    public static IEnumerable<TestCaseData> ClassWithPrivateMethodTypes => GetWovenTypes("ClassWithPrivateMethod");
+
+    public static IEnumerable<TestCaseData> IndexersClassTypes => GetWovenTypes("Indexers");
+
+    public static IEnumerable<TestCaseData> ClassToExcludeTypes => GetTypesWovenWithConfig("ClassToExclude");
+
+    public static IEnumerable<TestCaseData> GenericClassTypes => GetWovenTypes("GenericClass`1");
+
+    private static IEnumerable<TestCaseData> GetWovenTypes(string typeName)
     {
         yield return new TestCaseData(AssemblyWeaver.Assemblies[0].GetType(typeName)).SetName("net framework");
         yield return new TestCaseData(AssemblyWeaver.Assemblies[3].GetType(typeName)).SetName("net standard");
     }
 
-    public static IEnumerable<TestCaseData> GetTypesWovenWithConfig(string typeName)
+    private static IEnumerable<TestCaseData> GetTypesWovenWithConfig(string typeName)
     {
         yield return new TestCaseData(AssemblyWeaver.Assemblies[1].GetType(typeName)).SetName("net framework");
         yield return new TestCaseData(AssemblyWeaver.Assemblies[4].GetType(typeName)).SetName("net standard");

--- a/Tests/Helpers/TestCaseHelper.cs
+++ b/Tests/Helpers/TestCaseHelper.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+public static class TestCaseHelper
+{
+    public static IEnumerable<TestCaseData> GetWovenTypes(string typeName)
+    {
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[0].GetType(typeName)).SetName("net framework");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[3].GetType(typeName)).SetName("net standard");
+    }
+
+    public static IEnumerable<TestCaseData> GetTypesWovenWithConfig(string typeName)
+    {
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[1].GetType(typeName)).SetName("net framework");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[4].GetType(typeName)).SetName("net standard");
+    }
+}

--- a/Tests/Helpers/TestCaseHelper.cs
+++ b/Tests/Helpers/TestCaseHelper.cs
@@ -19,13 +19,13 @@ public static class TestCaseHelper
 
     private static IEnumerable<TestCaseData> GetWovenTypes(string typeName)
     {
-        yield return new TestCaseData(AssemblyWeaver.Assemblies[0].GetType(typeName)).SetName("net framework");
-        yield return new TestCaseData(AssemblyWeaver.Assemblies[3].GetType(typeName)).SetName("net standard");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[0].GetType(typeName)).SetDescription("net framework");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[3].GetType(typeName)).SetDescription("net standard");
     }
 
     private static IEnumerable<TestCaseData> GetTypesWovenWithConfig(string typeName)
     {
-        yield return new TestCaseData(AssemblyWeaver.Assemblies[1].GetType(typeName)).SetName("net framework");
-        yield return new TestCaseData(AssemblyWeaver.Assemblies[4].GetType(typeName)).SetName("net standard");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[1].GetType(typeName)).SetDescription("net framework");
+        yield return new TestCaseData(AssemblyWeaver.Assemblies[4].GetType(typeName)).SetDescription("net standard");
     }
 }

--- a/Tests/RewritingConstructors.cs
+++ b/Tests/RewritingConstructors.cs
@@ -4,20 +4,14 @@ using NUnit.Framework;
 [TestFixture]
 public class RewritingConstructors
 {
-    Type sampleClassType;
-    Type classToExcludeType;
-
     [SetUp]
     public void SetUp()
     {
-        sampleClassType = AssemblyWeaver.Assemblies[0].GetType("SimpleClass");
-        classToExcludeType = AssemblyWeaver.Assemblies[1].GetType("ClassToExclude");
-
         AssemblyWeaver.TestListener.Reset();
     }
 
-    [Test]
-    public void RequiresNonNullArgument()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
+    public void RequiresNonNullArgument(Type sampleClassType)
     {
         Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType, null, "")),
             Throws.TargetInvocationException
@@ -25,8 +19,8 @@ public class RewritingConstructors
                 .And.InnerException.Property("ParamName").EqualTo("nonNullArg"));
     }
 
-    [Test]
-    public void RequiresNonNullOutArgument()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
+    public void RequiresNonNullOutArgument(Type sampleClassType)
     {
         var args = new object[1];
         Assert.That(new TestDelegate(() => Activator.CreateInstance(sampleClassType, args)),
@@ -35,14 +29,14 @@ public class RewritingConstructors
         Assert.AreEqual("Fail: [NullGuard] Out parameter 'nonNullOutArg' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullWhenAttributeApplied()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
+    public void AllowsNullWhenAttributeApplied(Type sampleClassType)
     {
         Activator.CreateInstance(sampleClassType, "", null);
     }
 
-    [Test]
-    public void AllowsNullWhenClassMatchExcludeRegex()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.ClassToExcludeTypes))]
+    public void AllowsNullWhenClassMatchExcludeRegex(Type classToExcludeType)
     {
         Activator.CreateInstance(classToExcludeType, new object[]{ null });
     }

--- a/Tests/RewritingIndexers.cs
+++ b/Tests/RewritingIndexers.cs
@@ -4,18 +4,14 @@ using NUnit.Framework;
 [TestFixture]
 public class RewritingIndexers
 {
-    Type indexersClassType;
-
     [SetUp]
     public void SetUp()
     {
-        indexersClassType = AssemblyWeaver.Assemblies[0].GetType("Indexers");
-
         AssemblyWeaver.TestListener.Reset();
     }
 
-    [Test]
-    public void NonNullableIndexerSetterWithFirstArgumentNull()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerSetterWithFirstArgumentNull(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: null, nonNullParam2: null] = "value");
@@ -23,8 +19,8 @@ public class RewritingIndexers
         Assert.AreEqual("Fail: [NullGuard] nonNullParam1 is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void NonNullableIndexerSetterWithSecondArgumentNull()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerSetterWithSecondArgumentNull(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: null] = "value");
@@ -32,8 +28,8 @@ public class RewritingIndexers
         Assert.AreEqual("Fail: [NullGuard] nonNullParam2 is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void NonNullableIndexerSetterWithValueArgumentNull()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerSetterWithValueArgumentNull(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = null);
@@ -43,15 +39,15 @@ public class RewritingIndexers
             AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void NonNullableIndexerSetterWithNonNullArguments()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerSetterWithNonNullArguments(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = "value";
     }
 
-    [Test]
-    public void NonNullableIndexerGetterWithFirstArgumentNull()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerGetterWithFirstArgumentNull(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: null, nonNullParam2: null]));
@@ -59,8 +55,8 @@ public class RewritingIndexers
         Assert.AreEqual("Fail: [NullGuard] nonNullParam1 is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void NonNullableIndexerGetterWithSecondArgumentNull()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerGetterWithSecondArgumentNull(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: "arg 1", nonNullParam2: null]));
@@ -68,15 +64,15 @@ public class RewritingIndexers
         Assert.AreEqual("Fail: [NullGuard] nonNullParam2 is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void NonNullableIndexerGetterWithNonNullArguments()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void NonNullableIndexerGetterWithNonNullArguments(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("NonNullable"));
         Assert.AreEqual("return value of NonNullable", instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"]);
     }
 
-    [Test]
-    public void PassThroughGetterReturnValueWithNullArgument()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void PassThroughGetterReturnValueWithNullArgument(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("PassThroughGetterReturnValue"));
         Assert.Throws<InvalidOperationException>(() => IgnoreValue(instance[returnValue: null]));
@@ -85,22 +81,22 @@ public class RewritingIndexers
             AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void PassThroughGetterReturnValueWithNonNullArgument()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void PassThroughGetterReturnValueWithNonNullArgument(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("PassThroughGetterReturnValue"));
         Assert.AreEqual("not null", instance[returnValue: "not null"]);
     }
 
-    [Test]
-    public void AllowedNullsIndexerSetter()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void AllowedNullsIndexerSetter(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("AllowedNulls"));
         instance[allowNull: null, nullableInt: null] = null;
     }
 
-    [Test]
-    public void AllowedNullsIndexerGetter()
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.IndexersClassTypes))]
+    public void AllowedNullsIndexerGetter(Type indexersClassType)
     {
         var instance = (dynamic) Activator.CreateInstance(indexersClassType.GetNestedType("AllowedNulls"));
         Assert.AreEqual(null, instance[allowNull: null, nullableInt: null]);

--- a/Tests/RewritingMethods.cs
+++ b/Tests/RewritingMethods.cs
@@ -15,17 +15,7 @@ public class RewritingMethods
         AssemblyWeaver.TestListener.Reset();
     }
 
-    private static IEnumerable<TestCaseData> ClassWithExplicitInterfaceTypes => TestCaseHelper.GetWovenTypes("ClassWithExplicitInterface");
-
-    private static IEnumerable<TestCaseData> SampleClassTypes => TestCaseHelper.GetWovenTypes("SimpleClass");
-
-    private static IEnumerable<TestCaseData> SpecialClassTypes => TestCaseHelper.GetWovenTypes("SpecialClass");
-
-    private static IEnumerable<TestCaseData> ClassWithPrivateMethodTypes => TestCaseHelper.GetWovenTypes("ClassWithPrivateMethod");
-
-    private static IEnumerable<TestCaseData> ClassToExcludeTypes => TestCaseHelper.GetTypesWovenWithConfig("ClassToExclude");
-
-    [TestCaseSource(nameof(ClassWithExplicitInterfaceTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.ClassWithExplicitInterfaceTypes))]
     public void RequiresNonNullArgumentForExplicitInterface(Type classWithExplicitInterfaceType)
     {
         AssemblyWeaver.TestListener.Reset();
@@ -35,7 +25,7 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] other is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void RequiresNonNullArgument(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -44,14 +34,14 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] nonNullArg is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void AllowsNullWhenAttributeApplied(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.SomeMethod("", null);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void RequiresNonNullMethodReturnValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -59,7 +49,7 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'System.String SimpleClass::MethodWithReturnValue(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void RequiresNonNullGenericMethodReturnValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -67,14 +57,14 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'T SimpleClass::MethodWithGenericReturn(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void AllowsNullReturnValueWhenAttributeApplied(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodAllowsNullReturnValue();
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void RequiresNonNullOutValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -83,7 +73,7 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Out parameter 'nonNullOutArg' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void AllowsNullOutValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -91,21 +81,21 @@ public class RewritingMethods
         sample.MethodWithAllowedNullOutValue(out value);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void DoesNotRequireNonNullForNonPublicMethod(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.PublicWrapperOfPrivateMethod();
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void DoesNotRequireNonNullForOptionalParameter(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodWithOptionalParameter(optional: null);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void RequiresNonNullForOptionalParameterWithNonNullDefaultValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
@@ -114,14 +104,14 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] optional is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void DoesNotRequireNonNullForOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(optional: null);
     }
 
-    [TestCaseSource(nameof(ClassWithPrivateMethodTypes)), Explicit("Fails on AppVeyor - TODO")]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.ClassWithPrivateMethodTypes)), Explicit("Fails on AppVeyor - TODO")]
     public void RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic(Type classWithPrivateMethodType)
     {
         var sample = (dynamic)Activator.CreateInstance(classWithPrivateMethodType);
@@ -129,7 +119,7 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] x is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void ReturnGuardDoesNotInterfereWithIteratorMethod(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
@@ -138,7 +128,7 @@ public class RewritingMethods
 
 #if (DEBUG)
     
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void RequiresNonNullArgumentAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
@@ -147,14 +137,14 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] nonNullArg is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void AllowsNullWhenAttributeAppliedAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
         sample.SomeMethodAsync("", null);
     }
 
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void RequiresNonNullMethodReturnValueAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
@@ -175,7 +165,7 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'System.Threading.Tasks.Task`1<System.String> SpecialClass::MethodWithReturnValueAsync(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void AllowsNullReturnValueWhenAttributeAppliedAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
@@ -193,7 +183,7 @@ public class RewritingMethods
         Assert.Null(ex);
     }
 
-    [TestCaseSource(nameof(SpecialClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SpecialClassTypes))]
     public void NoAwaitWillCompile(Type specialClassType)
     {
         var instance = (dynamic)Activator.CreateInstance(specialClassType);
@@ -202,14 +192,14 @@ public class RewritingMethods
 
 #endif
 
-    [TestCaseSource(nameof(ClassToExcludeTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.ClassToExcludeTypes))]
     public void AllowsNullWhenClassMatchExcludeRegex(Type classToExcludeType)
     {
         var ClassToExclude = (dynamic)Activator.CreateInstance(classToExcludeType, "");
         ClassToExclude.Test(null);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void ReturnValueChecksWithBranchToRetInstruction(Type sampleClassType)
     {
         // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.
@@ -219,7 +209,7 @@ public class RewritingMethods
         Assert.AreEqual("[NullGuard] Return value of method 'System.String SimpleClass::ReturnValueChecksWithBranchToRetInstruction()' is null.", exception.Message);
     }
 
-    [TestCaseSource(nameof(SampleClassTypes))]
+    [TestCaseSource(typeof(TestCaseHelper), nameof(TestCaseHelper.SampleClassTypes))]
     public void OutValueChecksWithRetInstructionAsSwitchCase(Type sampleClassType)
     {
         // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.

--- a/Tests/RewritingMethods.cs
+++ b/Tests/RewritingMethods.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 #if (DEBUG)
 using System.Threading.Tasks;
 #endif
@@ -9,26 +9,24 @@ using NUnit.Framework;
 [TestFixture]
 public class RewritingMethods
 {
-    Type sampleClassType;
-    Type classWithPrivateMethodType;
-    Type specialClassType;
-    Type classToExcludeType;
-    Type classWithExplicitInterfaceType;
-
     [SetUp]
     public void SetUp()
     {
-        sampleClassType = AssemblyWeaver.Assemblies[0].GetType("SimpleClass");
-        classWithPrivateMethodType = AssemblyWeaver.Assemblies[0].GetType("ClassWithPrivateMethod");
-        specialClassType = AssemblyWeaver.Assemblies[0].GetType("SpecialClass");
-        classToExcludeType = AssemblyWeaver.Assemblies[1].GetType("ClassToExclude");
-        classWithExplicitInterfaceType = AssemblyWeaver.Assemblies[0].GetType("ClassWithExplicitInterface");
-
         AssemblyWeaver.TestListener.Reset();
     }
 
-    [Test]
-    public void RequiresNonNullArgumentForExplicitInterface()
+    private static IEnumerable<TestCaseData> ClassWithExplicitInterfaceTypes => TestCaseHelper.GetWovenTypes("ClassWithExplicitInterface");
+
+    private static IEnumerable<TestCaseData> SampleClassTypes => TestCaseHelper.GetWovenTypes("SimpleClass");
+
+    private static IEnumerable<TestCaseData> SpecialClassTypes => TestCaseHelper.GetWovenTypes("SpecialClass");
+
+    private static IEnumerable<TestCaseData> ClassWithPrivateMethodTypes => TestCaseHelper.GetWovenTypes("ClassWithPrivateMethod");
+
+    private static IEnumerable<TestCaseData> ClassToExcludeTypes => TestCaseHelper.GetTypesWovenWithConfig("ClassToExclude");
+
+    [TestCaseSource(nameof(ClassWithExplicitInterfaceTypes))]
+    public void RequiresNonNullArgumentForExplicitInterface(Type classWithExplicitInterfaceType)
     {
         AssemblyWeaver.TestListener.Reset();
         var sample = (IComparable<string>)Activator.CreateInstance(classWithExplicitInterfaceType);
@@ -37,8 +35,8 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] other is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void RequiresNonNullArgument()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void RequiresNonNullArgument(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         var exception = Assert.Throws<ArgumentNullException>(() => sample.SomeMethod(null, ""));
@@ -46,38 +44,38 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] nonNullArg is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullWhenAttributeApplied()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void AllowsNullWhenAttributeApplied(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.SomeMethod("", null);
     }
 
-    [Test]
-    public void RequiresNonNullMethodReturnValue()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void RequiresNonNullMethodReturnValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         Assert.Throws<InvalidOperationException>(() => sample.MethodWithReturnValue(true));
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'System.String SimpleClass::MethodWithReturnValue(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void RequiresNonNullGenericMethodReturnValue()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void RequiresNonNullGenericMethodReturnValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         Assert.Throws<InvalidOperationException>(() => sample.MethodWithGenericReturn<object>(true));
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'T SimpleClass::MethodWithGenericReturn(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullReturnValueWhenAttributeApplied()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void AllowsNullReturnValueWhenAttributeApplied(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodAllowsNullReturnValue();
     }
 
-    [Test]
-    public void RequiresNonNullOutValue()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void RequiresNonNullOutValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         string value;
@@ -85,30 +83,30 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Out parameter 'nonNullOutArg' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullOutValue()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void AllowsNullOutValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         string value;
         sample.MethodWithAllowedNullOutValue(out value);
     }
 
-    [Test]
-    public void DoesNotRequireNonNullForNonPublicMethod()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void DoesNotRequireNonNullForNonPublicMethod(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.PublicWrapperOfPrivateMethod();
     }
 
-    [Test]
-    public void DoesNotRequireNonNullForOptionalParameter()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void DoesNotRequireNonNullForOptionalParameter(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodWithOptionalParameter(optional: null);
     }
 
-    [Test]
-    public void RequiresNonNullForOptionalParameterWithNonNullDefaultValue()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void RequiresNonNullForOptionalParameterWithNonNullDefaultValue(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         var exception = Assert.Throws<ArgumentNullException>(() => sample.MethodWithOptionalParameterWithNonNullDefaultValue(optional: null));
@@ -116,32 +114,32 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] optional is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void DoesNotRequireNonNullForOptionalParameterWithNonNullDefaultValueButAllowNullAttribute()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void DoesNotRequireNonNullForOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(Type sampleClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(sampleClassType);
         sample.MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(optional: null);
     }
 
-    [Test, Explicit("Fails on AppVeyor - TODO")]
-    public void RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic()
+    [TestCaseSource(nameof(ClassWithPrivateMethodTypes)), Explicit("Fails on AppVeyor - TODO")]
+    public void RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic(Type classWithPrivateMethodType)
     {
         var sample = (dynamic)Activator.CreateInstance(classWithPrivateMethodType);
         Assert.Throws<ArgumentNullException>(() => sample.PublicWrapperOfPrivateMethod());
         Assert.AreEqual("Fail: [NullGuard] x is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void ReturnGuardDoesNotInterfereWithIteratorMethod()
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void ReturnGuardDoesNotInterfereWithIteratorMethod(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
         Assert.That(new[] { 0, 1, 2, 3, 4 }, Is.EquivalentTo(sample.CountTo(5)));
     }
 
 #if (DEBUG)
-
-    [Test]
-    public void RequiresNonNullArgumentAsync()
+    
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void RequiresNonNullArgumentAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
         var exception = Assert.Throws<ArgumentNullException>(() => sample.SomeMethodAsync(null, ""));
@@ -149,15 +147,15 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] nonNullArg is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullWhenAttributeAppliedAsync()
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void AllowsNullWhenAttributeAppliedAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
         sample.SomeMethodAsync("", null);
     }
 
-    [Test]
-    public void RequiresNonNullMethodReturnValueAsync()
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void RequiresNonNullMethodReturnValueAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
 
@@ -177,8 +175,8 @@ public class RewritingMethods
         Assert.AreEqual("Fail: [NullGuard] Return value of method 'System.Threading.Tasks.Task`1<System.String> SpecialClass::MethodWithReturnValueAsync(System.Boolean)' is null.", AssemblyWeaver.TestListener.Message);
     }
 
-    [Test]
-    public void AllowsNullReturnValueWhenAttributeAppliedAsync()
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void AllowsNullReturnValueWhenAttributeAppliedAsync(Type specialClassType)
     {
         var sample = (dynamic)Activator.CreateInstance(specialClassType);
 
@@ -195,8 +193,8 @@ public class RewritingMethods
         Assert.Null(ex);
     }
 
-    [Test]
-    public void NoAwaitWillCompile()
+    [TestCaseSource(nameof(SpecialClassTypes))]
+    public void NoAwaitWillCompile(Type specialClassType)
     {
         var instance = (dynamic)Activator.CreateInstance(specialClassType);
         Assert.AreEqual(42, instance.NoAwaitCode().Result);
@@ -204,15 +202,15 @@ public class RewritingMethods
 
 #endif
 
-    [Test]
-    public void AllowsNullWhenClassMatchExcludeRegex()
+    [TestCaseSource(nameof(ClassToExcludeTypes))]
+    public void AllowsNullWhenClassMatchExcludeRegex(Type classToExcludeType)
     {
         var ClassToExclude = (dynamic)Activator.CreateInstance(classToExcludeType, "");
         ClassToExclude.Test(null);
     }
 
-    [Test]
-    public void ReturnValueChecksWithBranchToRetInstruction()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void ReturnValueChecksWithBranchToRetInstruction(Type sampleClassType)
     {
         // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.
 
@@ -221,8 +219,8 @@ public class RewritingMethods
         Assert.AreEqual("[NullGuard] Return value of method 'System.String SimpleClass::ReturnValueChecksWithBranchToRetInstruction()' is null.", exception.Message);
     }
 
-    [Test]
-    public void OutValueChecksWithRetInstructionAsSwitchCase()
+    [TestCaseSource(nameof(SampleClassTypes))]
+    public void OutValueChecksWithRetInstructionAsSwitchCase(Type sampleClassType)
     {
         // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -46,7 +46,7 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\FodyCecil.2.0.7\lib\net40\Mono.Cecil.dll</HintPath>
@@ -74,9 +74,21 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.1.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
@@ -93,6 +105,7 @@
     <Compile Include="RewritingIndexers.cs" />
     <Compile Include="RewritingProperties.cs" />
     <Compile Include="RewritingMethods.cs" />
+    <Compile Include="Helpers\TestCaseHelper.cs" />
     <Compile Include="VerifyTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/VerifyTest.cs
+++ b/Tests/VerifyTest.cs
@@ -17,6 +17,18 @@ public class VerifyTest
         Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[1]);
     }
 
+    [Test]
+    public void PeVerifyNetStandard1()
+    {
+        Verifier.Verify(AssemblyWeaver.NetStandardBeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[3]);
+    }
+
+    [Test]
+    public void PeVerifyNetStandard2()
+    {
+        Verifier.Verify(AssemblyWeaver.NetStandardBeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPaths[4]);
+    }
+
     //[Test]
     //public void PeVerify3()
     //{

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -6,4 +6,7 @@
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
   <package id="NServiceBus" version="6.2.1" targetFramework="net462" />
   <package id="NUnit" version="3.6.1" targetFramework="net462" />
+  <package id="System.Console" version="4.0.0" targetFramework="net462" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Another attempt to fix #65 and fix #69

Instead of switching all projects, I only created the reference assembly and the assembly to process targetting .NET Standard/Core. Apparently both types of csproj cannot exist beside each other in a single solution. Is it a fact or just me? To overcome that I created a second sln and `Fody.csproj` calls `dotnet` to build the new stuff. Ugly but works.