### PR TITLE
Support for ItemCanBeNullAttribute

### DIFF
--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -7,6 +7,7 @@ public static class CecilExtensions
 {
     const string AllowNullAttributeTypeName = "AllowNullAttribute";
     const string CanBeNullAttributeTypeName = "CanBeNullAttribute";
+    const string ItemCanBeNullAttributeTypeName = "ItemCanBeNullAttribute";
 
     public static bool HasInterface(this TypeDefinition type, string interfaceFullName)
     {
@@ -50,7 +51,7 @@ public static class CecilExtensions
     {
         return methodDefinition.MethodReturnType.CustomAttributes.Any(a => a.AttributeType.Name == AllowNullAttributeTypeName) ||
                // ReSharper uses a *method* attribute for CanBeNull for the return value
-               methodDefinition.CustomAttributes.Any(a => a.AttributeType.Name == CanBeNullAttributeTypeName);
+               methodDefinition.CustomAttributes.Any(a => a.AttributeType.Name == CanBeNullAttributeTypeName || a.AttributeType.Name == ItemCanBeNullAttributeTypeName);
     }
 
     public static bool ContainsAllowNullAttribute(this ICustomAttributeProvider definition)


### PR DESCRIPTION
Add initial support for resharper `ItemCanBeNullAttribute`.  This attribute provides a hint that `Task.Result` property or of the `Lazy.Value` property can be `null`.  For NullGuard's purpose, this is only interesting on the return value, which is why it was only implemented in the one place.

More about this attribute can be found here: [Resharper ItemCanBeNullAttribute](https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#ItemCanBeNullAttribute)

An example of the use of this is

```csharp
[ItemCanBeNull]
public async Task<string> GetNullString() 
{
    return null;
}
```