### PR TITLE
Explicit mode

### DIFF
--- a/AssemblyToProcessExplicit/AssemblyToProcessExplicit.csproj
+++ b/AssemblyToProcessExplicit/AssemblyToProcessExplicit.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;JETBRAINS_ANNOTATIONS</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj" />
+  </ItemGroup>
+</Project>

--- a/AssemblyToProcessExplicit/BaseClassWithAttributes.cs
+++ b/AssemblyToProcessExplicit/BaseClassWithAttributes.cs
@@ -1,0 +1,122 @@
+﻿using JetBrains.Annotations;
+
+using NullGuard;
+
+public abstract class BaseClassWithAttributes
+{
+    public abstract void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+    [NotNull]
+    public abstract string MethodWithNotNullReturnValue(string arg);
+
+    [NotNull]
+    public abstract string NotNullProperty { get; set; }
+}
+
+public interface BaseInterfaceWithAttributes
+{
+    void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+    [NotNull]
+    string MethodWithNotNullReturnValue(string arg);
+
+    [NotNull]
+    string NotNullProperty { get; set; }
+}
+
+public interface InheritedInterface : BaseInterfaceWithAttributes
+{
+    
+}
+
+public interface InterfaceWithAttributes
+{
+    void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+    [NotNull]
+    string MethodWithNotNullReturnValue(string arg);
+
+    [NotNull]
+    string NotNullProperty { get; set; }
+}
+
+
+
+public class DerivedClass : BaseClassWithAttributes
+{
+    public override void MethodWithNotNullParameter(string canBeNull, string arg)
+    {
+    }
+
+    public override string MethodWithNotNullReturnValue(string arg)
+    {
+        return arg;
+    }
+
+    public override string NotNullProperty { get; set; }
+}
+
+public class ImplementsInterface : InterfaceWithAttributes
+{
+    public void MethodWithNotNullParameter(string canBeNull, string arg)
+    {
+    }
+
+    public string MethodWithNotNullReturnValue(string arg)
+    {
+        return arg;
+    }
+
+    public string NotNullProperty { get; set; }
+}
+
+public class ImplementsInheritedInterface : InheritedInterface
+{
+    public void MethodWithNotNullParameter(string canBeNull, string arg)
+    {
+    }
+
+    public string MethodWithNotNullReturnValue(string arg)
+    {
+        return arg;
+    }
+
+    public string NotNullProperty { get; set; }
+}
+
+[NullGuard(ValidationFlags.All)] // TODO: need this due to https://github.com/Fody/NullGuard/issues/37 https://github.com/Fody/NullGuard/issues/60, remove after fix of #60
+public class ImplementsInterfaceExplicit : InterfaceWithAttributes
+{
+    public void MethodWithNotNullParameter(string canBeNull, string arg)
+    {
+        ((InterfaceWithAttributes)this).MethodWithNotNullParameter(canBeNull, arg);
+    }
+
+    public string MethodWithNotNullReturnValue(string arg)
+    {
+        return ((InterfaceWithAttributes)this).MethodWithNotNullReturnValue(arg);
+    }
+
+    public string NotNullProperty
+    {
+        get => ((InterfaceWithAttributes)this).NotNullProperty;
+        set => ((InterfaceWithAttributes)this).NotNullProperty = value;
+    }
+
+    void InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull, string arg)
+    {
+    }
+
+    string InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg)
+    {
+        return arg;
+    }
+
+    string InterfaceWithAttributes.NotNullProperty
+    {
+        get;
+        set;
+    }
+}
+
+

--- a/AssemblyToProcessExplicit/BaseClassWithAttributes.cs
+++ b/AssemblyToProcessExplicit/BaseClassWithAttributes.cs
@@ -26,7 +26,7 @@ public interface BaseInterfaceWithAttributes
 
 public interface InheritedInterface : BaseInterfaceWithAttributes
 {
-    
+
 }
 
 public interface InterfaceWithAttributes
@@ -40,83 +40,242 @@ public interface InterfaceWithAttributes
     string NotNullProperty { get; set; }
 }
 
-
-
-public class DerivedClass : BaseClassWithAttributes
+namespace InternalBase
 {
-    public override void MethodWithNotNullParameter(string canBeNull, string arg)
+    public class DerivedClass : BaseClassWithAttributes
     {
+        public override void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public override string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public override string NotNullProperty { get; set; }
     }
 
-    public override string MethodWithNotNullReturnValue(string arg)
+    public class ImplementsInterface : InterfaceWithAttributes
     {
-        return arg;
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
     }
 
-    public override string NotNullProperty { get; set; }
+    public class ImplementsInheritedInterface : InheritedInterface
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
+    }
+
+    [NullGuard(ValidationFlags.All)] // TODO: need this due to https://github.com/Fody/NullGuard/issues/37 https://github.com/Fody/NullGuard/issues/60, remove after fix of #60
+    public class ImplementsInterfaceExplicit : InterfaceWithAttributes
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+            ((InterfaceWithAttributes)this).MethodWithNotNullParameter(canBeNull, arg);
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return ((InterfaceWithAttributes)this).MethodWithNotNullReturnValue(arg);
+        }
+
+        public string NotNullProperty
+        {
+            get => ((InterfaceWithAttributes)this).NotNullProperty;
+            set => ((InterfaceWithAttributes)this).NotNullProperty = value;
+        }
+
+        void InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        string InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        string InterfaceWithAttributes.NotNullProperty
+        {
+            get;
+            set;
+        }
+    }
 }
 
-public class ImplementsInterface : InterfaceWithAttributes
+namespace AssemblyBase
 {
-    public void MethodWithNotNullParameter(string canBeNull, string arg)
+    public class DerivedClass : AssemblyWithAnnotations.BaseClassWithAttributes
     {
+        public override void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public override string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public override string NotNullProperty { get; set; }
     }
 
-    public string MethodWithNotNullReturnValue(string arg)
+    public class ImplementsInterface : AssemblyWithAnnotations.InterfaceWithAttributes
     {
-        return arg;
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
     }
 
-    public string NotNullProperty { get; set; }
+    public class ImplementsInheritedInterface : AssemblyWithAnnotations.InheritedInterface
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
+    }
+
+    [NullGuard(ValidationFlags.All)] // TODO: need this due to https://github.com/Fody/NullGuard/issues/37 https://github.com/Fody/NullGuard/issues/60, remove after fix of #60
+    public class ImplementsInterfaceExplicit : AssemblyWithAnnotations.InterfaceWithAttributes
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+            ((AssemblyWithAnnotations.InterfaceWithAttributes)this).MethodWithNotNullParameter(canBeNull, arg);
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return ((AssemblyWithAnnotations.InterfaceWithAttributes)this).MethodWithNotNullReturnValue(arg);
+        }
+
+        public string NotNullProperty
+        {
+            get => ((AssemblyWithAnnotations.InterfaceWithAttributes)this).NotNullProperty;
+            set => ((AssemblyWithAnnotations.InterfaceWithAttributes)this).NotNullProperty = value;
+        }
+
+        void AssemblyWithAnnotations.InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        string AssemblyWithAnnotations.InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        string AssemblyWithAnnotations.InterfaceWithAttributes.NotNullProperty
+        {
+            get;
+            set;
+        }
+    }
 }
 
-public class ImplementsInheritedInterface : InheritedInterface
+namespace ExternalBase
 {
-    public void MethodWithNotNullParameter(string canBeNull, string arg)
+    public class DerivedClass : AssemblyWithExternalAnnotations.BaseClassWithAttributes
     {
+        public override void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public override string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public override string NotNullProperty { get; set; }
     }
 
-    public string MethodWithNotNullReturnValue(string arg)
+    public class ImplementsInterface : AssemblyWithExternalAnnotations.InterfaceWithAttributes
     {
-        return arg;
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
     }
 
-    public string NotNullProperty { get; set; }
+    public class ImplementsInheritedInterface : AssemblyWithExternalAnnotations.InheritedInterface
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        public string NotNullProperty { get; set; }
+    }
+
+    [NullGuard(ValidationFlags.All)] // TODO: need this due to https://github.com/Fody/NullGuard/issues/37 https://github.com/Fody/NullGuard/issues/60, remove after fix of #60
+    public class ImplementsInterfaceExplicit : AssemblyWithExternalAnnotations.InterfaceWithAttributes
+    {
+        public void MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+            ((AssemblyWithExternalAnnotations.InterfaceWithAttributes)this).MethodWithNotNullParameter(canBeNull, arg);
+        }
+
+        public string MethodWithNotNullReturnValue(string arg)
+        {
+            return ((AssemblyWithExternalAnnotations.InterfaceWithAttributes)this).MethodWithNotNullReturnValue(arg);
+        }
+
+        public string NotNullProperty
+        {
+            get => ((AssemblyWithExternalAnnotations.InterfaceWithAttributes)this).NotNullProperty;
+            set => ((AssemblyWithExternalAnnotations.InterfaceWithAttributes)this).NotNullProperty = value;
+        }
+
+        void AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull, string arg)
+        {
+        }
+
+        string AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg)
+        {
+            return arg;
+        }
+
+        string AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty
+        {
+            get;
+            set;
+        }
+    }
 }
-
-[NullGuard(ValidationFlags.All)] // TODO: need this due to https://github.com/Fody/NullGuard/issues/37 https://github.com/Fody/NullGuard/issues/60, remove after fix of #60
-public class ImplementsInterfaceExplicit : InterfaceWithAttributes
-{
-    public void MethodWithNotNullParameter(string canBeNull, string arg)
-    {
-        ((InterfaceWithAttributes)this).MethodWithNotNullParameter(canBeNull, arg);
-    }
-
-    public string MethodWithNotNullReturnValue(string arg)
-    {
-        return ((InterfaceWithAttributes)this).MethodWithNotNullReturnValue(arg);
-    }
-
-    public string NotNullProperty
-    {
-        get => ((InterfaceWithAttributes)this).NotNullProperty;
-        set => ((InterfaceWithAttributes)this).NotNullProperty = value;
-    }
-
-    void InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull, string arg)
-    {
-    }
-
-    string InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg)
-    {
-        return arg;
-    }
-
-    string InterfaceWithAttributes.NotNullProperty
-    {
-        get;
-        set;
-    }
-}
-
-

--- a/AssemblyToProcessExplicit/ClassToExclude.cs
+++ b/AssemblyToProcessExplicit/ClassToExclude.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+
+public class ClassToExclude
+{
+    // ReSharper disable once UnusedParameter.Local
+    public ClassToExclude([NotNull] string test)
+    {
+    }
+
+    [NotNull]
+    public string Test([NotNull] string text)
+    {
+        return text;
+    }
+
+    [NotNull]
+    public string Property { get; set; }
+}

--- a/AssemblyToProcessExplicit/ClassWithBadAttributes.cs
+++ b/AssemblyToProcessExplicit/ClassWithBadAttributes.cs
@@ -1,0 +1,11 @@
+using NullGuard;
+
+public abstract class ClassWithBadAttributes
+{
+    public abstract void MethodWithNoNullCheckOnParam([AllowNull] string arg);
+    public abstract string PropertyWithNoNullCheckOnSet { get; [param: AllowNull] set; }
+    public abstract string PropertyAllowsNullGetButDoesNotAllowNullSet { [return: AllowNull] get; set; }
+
+    [return: AllowNull]
+    public abstract string MethodAllowsNullReturnValue();
+}

--- a/AssemblyToProcessExplicit/ClassWithExplicitInterface.cs
+++ b/AssemblyToProcessExplicit/ClassWithExplicitInterface.cs
@@ -1,0 +1,11 @@
+using System;
+
+using JetBrains.Annotations;
+
+public class ClassWithExplicitInterface : IComparable<string>
+{
+    int IComparable<string>.CompareTo([NotNull] string other)
+    {
+        return 0;
+    }
+}

--- a/AssemblyToProcessExplicit/ClassWithPrivateMethod.cs
+++ b/AssemblyToProcessExplicit/ClassWithPrivateMethod.cs
@@ -1,0 +1,21 @@
+using JetBrains.Annotations;
+
+using NullGuard;
+
+[NullGuard(ValidationFlags.NonPublic | ValidationFlags.Arguments)]
+public class ClassWithPrivateMethod
+{
+    public void PublicWrapperOfPrivateMethod()
+    {
+        SomePrivateMethod(null);
+    }
+
+    // ReSharper disable UnusedParameter.Local
+    void SomePrivateMethod([NotNull] string x)
+    // ReSharper restore UnusedParameter.Local
+    {
+    }
+
+    [NotNull]
+    public string SomeProperty { get; set; }
+}

--- a/AssemblyToProcessExplicit/GenericClass.cs
+++ b/AssemblyToProcessExplicit/GenericClass.cs
@@ -1,0 +1,4 @@
+public class GenericClass<T> {
+    [JetBrains.Annotations.NotNull]
+    public T NonNullProperty { get; set; }
+}

--- a/AssemblyToProcessExplicit/IXamlMetadataProvider.cs
+++ b/AssemblyToProcessExplicit/IXamlMetadataProvider.cs
@@ -1,0 +1,4 @@
+namespace Windows.UI.Xaml.Markup
+{
+    public interface IXamlMetadataProvider{}
+}

--- a/AssemblyToProcessExplicit/Indexers.cs
+++ b/AssemblyToProcessExplicit/Indexers.cs
@@ -1,0 +1,31 @@
+using JetBrains.Annotations;
+using NullGuard;
+
+public class Indexers
+{
+    public class NonNullable
+    {
+        [NotNull]
+        public string this[[NotNull] string nonNullParam1, [NotNull] string nonNullParam2]
+        {
+            get { return "return value of NonNullable"; }
+            set { }
+        }
+    }
+
+    public class PassThroughGetterReturnValue
+    {
+        [NotNull]
+        public string this[[CanBeNull] string returnValue] => returnValue;
+    }
+
+    public class AllowedNulls
+    {
+        [CanBeNull]
+        public string this[[CanBeNull] string allowNull, int? nullableInt, string optional = null]
+        {
+            get { return null; }
+            set { }
+        }
+    }
+}

--- a/AssemblyToProcessExplicit/InterfaceBadAttributes.cs
+++ b/AssemblyToProcessExplicit/InterfaceBadAttributes.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+
+using NullGuard;
+
+internal interface InterfaceBadAttributes
+{
+    void MethodWithNoNullCheckOnParam([CanBeNull] string arg);
+    [NotNull]
+    string PropertyWithNoNullCheckOnSet { get; [param: AllowNull] set; }
+    [NotNull]
+    string PropertyAllowsNullGetButDoesNotAllowNullSet { [return: AllowNull] get; set; }
+    [return: AllowNull]
+    string MethodAllowsNullReturnValue();
+}

--- a/AssemblyToProcessExplicit/NonPublicWithNested.cs
+++ b/AssemblyToProcessExplicit/NonPublicWithNested.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+
+internal class NonPublicWithNested
+{
+    public class PublicNestedClass
+    {
+        [NotNull]
+        public string MethodReturnsNull()
+        {
+            return null;
+        }
+    }
+}

--- a/AssemblyToProcessExplicit/Sample/Sample.cs
+++ b/AssemblyToProcessExplicit/Sample/Sample.cs
@@ -1,0 +1,32 @@
+    using JetBrains.Annotations;
+
+    using NullGuard;
+
+
+    public class Sample
+    {
+        public void SomeMethod(string arg)
+        {
+            // throws ArgumentNullException if arg is null.
+        }
+
+        public void AnotherMethod([CanBeNull] string arg)
+        {
+            // arg may be null here
+        }
+
+        public string MethodWithReturn()
+        {
+            return SomeOtherClass.SomeMethod();
+        }
+
+        // Null checking works for automatic properties too.
+        public string SomeProperty { get; set; }
+
+        // can be applied to a whole property
+        [CanBeNull] 
+        public string NullProperty { get; set; }
+
+        // Or just the setter.
+        public string NullPropertyOnSet { get; [param: AllowNull] set; }
+    }

--- a/AssemblyToProcessExplicit/Sample/SampleOutput.cs
+++ b/AssemblyToProcessExplicit/Sample/SampleOutput.cs
@@ -1,0 +1,65 @@
+    using System;
+
+    public class SampleOutput
+    {
+
+        public string NullProperty { get; set; }
+
+        string nullPropertyOnSet;
+        public string NullPropertyOnSet
+        {
+            get
+            {
+                var returnValue = nullPropertyOnSet;
+                if (returnValue == null)
+                {
+                    throw new InvalidOperationException("Return value of property 'NullPropertyOnSet' is null.");
+                }
+                return returnValue;
+            }
+            set => nullPropertyOnSet = value;
+        }
+
+        string someProperty;
+        public string SomeProperty
+        {
+            get
+            {
+                if (someProperty == null)
+                {
+                    throw new InvalidOperationException("Return value of property 'SomeProperty' is null.");
+                }
+                return someProperty;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value", "Cannot set the value of property 'SomeProperty' to null.");
+                }
+                someProperty = value;
+            }
+        }
+
+        public void AnotherMethod(string arg)
+        {
+        }
+
+        public string MethodWithReturn()
+        {
+            var returnValue = SomeOtherClass.SomeMethod();
+            if (returnValue == null)
+            {
+                throw new InvalidOperationException("Return value of method 'MethodWithReturn' is null.");
+            }
+            return returnValue;
+        }
+
+        public void SomeMethod(string arg)
+        {
+            if (arg == null)
+            {
+                throw new ArgumentNullException("arg");
+            }
+        }
+    }

--- a/AssemblyToProcessExplicit/Sample/SomeOtherClass.cs
+++ b/AssemblyToProcessExplicit/Sample/SomeOtherClass.cs
@@ -1,0 +1,7 @@
+public class SomeOtherClass
+{
+    public static string SomeMethod()
+    {
+        return null;
+    }
+}

--- a/AssemblyToProcessExplicit/SimpleClass.cs
+++ b/AssemblyToProcessExplicit/SimpleClass.cs
@@ -1,0 +1,221 @@
+using System;
+
+using JetBrains.Annotations;
+
+using NullGuard;
+
+public class SimpleClass
+{
+    public SimpleClass()
+    {
+    }
+
+    // Why would anyone place an out parameter on a ctor?! I don't know, but I'll support your idiocy.
+    public SimpleClass([NotNull] out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public SimpleClass([NotNull] string nonNullArg, [CanBeNull] string nullArg)
+    {
+        Console.WriteLine(nonNullArg + " " + nullArg);
+    }
+
+    public void SomeMethod([NotNull] string nonNullArg, [CanBeNull] string nullArg)
+    {
+        Console.WriteLine(nonNullArg);
+    }
+
+    [NotNull]
+    public string NonNullProperty { get; set; }
+
+    [CanBeNull]
+    public string NullProperty { get; set; }
+
+    [NotNull]
+    public string PropertyAllowsNullGetButDoesNotAllowNullSet { [return: AllowNull] get; set; }
+
+    [NotNull]
+    public string PropertyAllowsNullSetButDoesNotAllowNullGet { get; [param: AllowNull] set; }
+
+    public int? NonNullNullableProperty { get; set; }
+
+    [NotNull]
+    public string MethodWithReturnValue(bool returnNull)
+    {
+        return returnNull ? null : "";
+    }
+
+    public void MethodWithRef([NotNull] ref object returnNull)
+    {
+    }
+
+    public void MethodWithGeneric<T>([NotNull] T returnNull)
+    {
+    }
+
+    public void MethodWithGenericRef<T>([NotNull] ref T returnNull)
+    {
+    }
+
+    [return: AllowNull]
+    public string MethodAllowsNullReturnValue()
+    {
+        return null;
+    }
+
+    [CanBeNull]
+    public string MethodWithCanBeNullResult()
+    {
+        return null;
+    }
+
+    public void MethodWithOutValue([NotNull] out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public void MethodWithAllowedNullOutValue([CanBeNull]out string nonNullOutArg)
+    {
+        nonNullOutArg = null;
+    }
+
+    public void PublicWrapperOfPrivateMethod()
+    {
+        SomePrivateMethod(null);
+    }
+
+    void SomePrivateMethod([NotNull] string x)
+    {
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithTwoRefs([NotNull] ref string first, [NotNull] ref string second)
+    {
+    }
+
+    public void MethodWithTwoOuts([NotNull] out string first, [NotNull] out string second)
+    {
+        first = null;
+        second = null;
+    }
+
+    public void MethodWithOptionalParameter(string optional = null)
+    {
+    }
+
+    public void MethodWithOptionalParameterWithNonNullDefaultValue([NotNull] string optional = "default")
+    {
+    }
+
+    public void MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute([CanBeNull] string optional = "default")
+    {
+    }
+
+    public void MethodWithGenericOut<T>([NotNull] out T item)
+    {
+        item = default;
+    }
+
+    [NotNull]
+    public T MethodWithGenericReturn<T>(bool returnNull)
+    {
+        return returnNull ? default : Activator.CreateInstance<T>();
+    }
+
+    [NotNull]
+    public object MethodWithOutAndReturn([NotNull] out string prefix)
+    {
+        prefix = null;
+        return null;
+    }
+
+    public void MethodWithExistingArgumentGuard([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentException("x is null or empty.", "x");
+
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithExistingArgumentNullGuard([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentNullException("x");
+
+        Console.WriteLine(x);
+    }
+
+    public void MethodWithExistingArgumentNullGuardWithMessage([NotNull] string x)
+    {
+        if (string.IsNullOrEmpty(x))
+            throw new ArgumentNullException("x", "x is null or empty.");
+
+        Console.WriteLine(x);
+    }
+
+    [NotNull]
+    public string ReturnValueChecksWithBranchToRetInstruction()
+    {
+        // This is a regression test scenario for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/57.
+
+        // It is important that the return value is assigned *before* the branch, otherwise the C# compiler emits
+        // instructions before the RET instructions, which wouldn't trigger the original issue.
+        string returnValue = null;
+
+        // The following, not-reachable, branch will jump directly to the RET statement (at least with Roslyn 1.0 with
+        // enabled optimizations flag) which triggers the issue (the return value checks will be skipped).
+        if ("".Length == 42)
+            throw new Exception("Not reachable");
+
+        return returnValue;
+    }
+
+    public void OutValueChecksWithBranchToRetInstruction([NotNull] out string outParam)
+    {
+        // This is the same scenario as above, but for out parameters.
+
+        outParam = null;
+
+        if ("".Length == 42)
+            throw new Exception("Not reachable");
+    }
+
+    [NotNull]
+    public string GetterReturnValueChecksWithBranchToRetInstruction
+    {
+        get
+        {
+            // This is the same scenario as above, but for property getters.
+
+            string returnValue = null;
+
+            if ("".Length == 42)
+                throw new Exception("Not reachable");
+
+            return returnValue;
+        }
+    }
+
+    public void OutValueChecksWithRetInstructionAsSwitchCase(int i, [NotNull] out string outParam)
+    {
+        // This is the same scenario as above, but with a SWITCH instruction with branch targets to RET
+        // instructions (they are handled specially).
+        // Note that its important to have more than sections to prove that all sections with only a RET instruction are handled.
+
+        outParam = null;
+        switch (i)
+        {
+            case 0:
+                return;
+            case 1:
+                Console.WriteLine("1");
+                break;
+            case 2:
+                return;
+            case 3:
+                Console.WriteLine("3");
+                break;
+        }
+    }
+}

--- a/AssemblyToProcessExplicit/SpecialClass.cs
+++ b/AssemblyToProcessExplicit/SpecialClass.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+#if (DEBUG)
+using System;
+using System.Threading.Tasks;
+using NullGuard;
+#endif
+
+public class SpecialClass
+{
+    [NotNull]
+    public IEnumerable<int> CountTo(int end)
+    {
+        for (var i = 0; i < end; i++)
+        {
+            yield return i;
+        }
+    }
+
+#if (DEBUG)
+
+    public async Task SomeMethodAsync([NotNull] string nonNullArg, [CanBeNull] string nullArg)
+    {
+        await Task.Run(() => Console.WriteLine(nonNullArg));
+    }
+
+    [NotNull]
+    public async Task<string> MethodWithReturnValueAsync(bool returnNull)
+    {
+        return await Task.Run(() => returnNull ? null : "");
+    }
+
+    [return: AllowNull]
+    public async Task<string> MethodAllowsNullReturnValueAsync()
+    {
+        await Task.Delay(100);
+
+        return null;
+    }
+
+#pragma warning disable 1998
+
+    [NotNull]
+    public async Task<int> NoAwaitCode()
+    {
+        return 42;
+    }
+
+#pragma warning restore 1998
+#endif
+}

--- a/AssemblyToProcessExplicit/UnsafeClass.cs
+++ b/AssemblyToProcessExplicit/UnsafeClass.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+
+public class UnsafeClass
+{
+    [NotNull]
+    unsafe public int* MethodWithAmp([NotNull] int* instance)
+    {
+        return default;
+    }
+
+    [NotNull]
+    unsafe public int* NullProperty { get; set; }
+}

--- a/AssemblyToProcessExplicit/XamlMetadataProvider.cs
+++ b/AssemblyToProcessExplicit/XamlMetadataProvider.cs
@@ -1,0 +1,6 @@
+using Windows.UI.Xaml.Markup;
+
+public class XamlMetadataProvider : IXamlMetadataProvider
+{
+    
+}

--- a/AssemblyWithAnnotations/AssemblyWithAnnotations.csproj
+++ b/AssemblyWithAnnotations/AssemblyWithAnnotations.csproj
@@ -1,10 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;JETBRAINS_ANNOTATIONS</DefineConstants>
@@ -15,9 +13,5 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AssemblyWithAnnotations\AssemblyWithAnnotations.csproj" />
-    <ProjectReference Include="..\AssemblyWithExternalAnnotations\AssemblyWithExternalAnnotations.csproj" />
-    <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj" />
-  </ItemGroup>
+
 </Project>

--- a/AssemblyWithAnnotations/BaseClassWithAttributes.cs
+++ b/AssemblyWithAnnotations/BaseClassWithAttributes.cs
@@ -1,0 +1,42 @@
+﻿namespace AssemblyWithAnnotations
+{
+    using JetBrains.Annotations;
+
+    public abstract class BaseClassWithAttributes
+    {
+        public abstract void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        public abstract string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        public abstract string NotNullProperty { get; set; }
+    }
+
+    public interface BaseInterfaceWithAttributes
+    {
+        void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        string NotNullProperty { get; set; }
+    }
+
+    public interface InheritedInterface : BaseInterfaceWithAttributes
+    {
+    
+    }
+
+    public interface InterfaceWithAttributes
+    {
+        void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        string NotNullProperty { get; set; }
+    }
+}

--- a/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.ExternalAnnotations.xml
+++ b/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.ExternalAnnotations.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly name="AssemblyWithExternalAnnotations">
+  <member name="M:AssemblyWithExternalAnnotations.BaseClassWithAttributes.MethodWithNotNullParameter(System.String,System.String)">
+    <parameter name="arg">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:AssemblyWithExternalAnnotations.BaseClassWithAttributes.MethodWithNotNullReturnValue(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:AssemblyWithExternalAnnotations.BaseClassWithAttributes.NotNullProperty">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="M:AssemblyWithExternalAnnotations.BaseInterfaceWithAttributes.MethodWithNotNullParameter(System.String,System.String)">
+    <parameter name="arg">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:AssemblyWithExternalAnnotations.BaseInterfaceWithAttributes.MethodWithNotNullReturnValue(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:AssemblyWithExternalAnnotations.BaseInterfaceWithAttributes.NotNullProperty">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="M:AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullParameter(System.String,System.String)">
+    <parameter name="arg">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullReturnValue(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+</assembly>

--- a/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.csproj
+++ b/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
@@ -11,7 +10,17 @@
     <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="AssemblyWithExternalAnnotations.ExternalAnnotations.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="AssemblyWithExternalAnnotations.ExternalAnnotations.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fody" Version="2.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+    <PackageReference Include="JetBrainsAnnotations.Fody" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.csproj
+++ b/AssemblyWithExternalAnnotations/AssemblyWithExternalAnnotations.csproj
@@ -1,10 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;JETBRAINS_ANNOTATIONS</DefineConstants>
@@ -15,9 +13,5 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AssemblyWithAnnotations\AssemblyWithAnnotations.csproj" />
-    <ProjectReference Include="..\AssemblyWithExternalAnnotations\AssemblyWithExternalAnnotations.csproj" />
-    <ProjectReference Include="..\ReferenceAssembly\ReferenceAssembly.csproj" />
-  </ItemGroup>
+
 </Project>

--- a/AssemblyWithExternalAnnotations/BaseClassWithAttributes.cs
+++ b/AssemblyWithExternalAnnotations/BaseClassWithAttributes.cs
@@ -1,0 +1,42 @@
+﻿namespace AssemblyWithExternalAnnotations
+{
+    using JetBrains.Annotations;
+
+    public abstract class BaseClassWithAttributes
+    {
+        public abstract void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        public abstract string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        public abstract string NotNullProperty { get; set; }
+    }
+
+    public interface BaseInterfaceWithAttributes
+    {
+        void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        string NotNullProperty { get; set; }
+    }
+
+    public interface InheritedInterface : BaseInterfaceWithAttributes
+    {
+    
+    }
+
+    public interface InterfaceWithAttributes
+    {
+        void MethodWithNotNullParameter(string canBeNull, [NotNull] string arg);
+
+        [NotNull]
+        string MethodWithNotNullReturnValue(string arg);
+
+        [NotNull]
+        string NotNullProperty { get; set; }
+    }
+}

--- a/AssemblyWithExternalAnnotations/FodyWeavers.xml
+++ b/AssemblyWithExternalAnnotations/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <JetBrainsAnnotations />
+</Weavers>

--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -41,16 +41,48 @@ public static class CecilExtensions
         return method.Parameters.Last();
     }
 
-    public static bool AllowsNull(this ICustomAttributeProvider value)
+    public static bool AllowsNull(this ParameterDefinition parameter, MethodDefinition method, NullGuardMode mode)
+    {
+        if (mode == NullGuardMode.Explicit)
+        {
+            return ExplicitMode.AllowsNull(parameter, method);
+        }
+        else
+        {
+            return parameter.ImplicitAllowsNull();
+        }
+    }
+
+    public static bool AllowsNull(this PropertyDefinition property, NullGuardMode mode)
+    {
+        if (mode == NullGuardMode.Explicit)
+        {
+            return ExplicitMode.AllowsNull(property);
+        }
+        else
+        {
+            return property.ImplicitAllowsNull();
+        }
+    }
+
+    public static bool ImplicitAllowsNull(this ICustomAttributeProvider value)
     {
         return value.CustomAttributes.Any(a => a.AttributeType.Name == AllowNullAttributeTypeName || a.AttributeType.Name == CanBeNullAttributeTypeName);
     }
 
-    public static bool AllowsNullReturnValue(this MethodDefinition methodDefinition)
+    public static bool AllowsNullReturnValue(this MethodDefinition methodDefinition, NullGuardMode mode)
     {
-        return methodDefinition.MethodReturnType.CustomAttributes.Any(a => a.AttributeType.Name == AllowNullAttributeTypeName) ||
-               // ReSharper uses a *method* attribute for CanBeNull for the return value
-               methodDefinition.CustomAttributes.Any(a => a.AttributeType.Name == CanBeNullAttributeTypeName);
+        if (mode == NullGuardMode.Explicit)
+        {
+            // ReSharper uses a *method* attribute for NotNull for the return value
+            return ExplicitMode.AllowsNull(methodDefinition);
+        }
+        else
+        {
+            return methodDefinition.MethodReturnType.CustomAttributes.Any(a => a.AttributeType.Name == AllowNullAttributeTypeName) ||
+                   // ReSharper uses a *method* attribute for CanBeNull for the return value
+                   methodDefinition.CustomAttributes.Any(a => a.AttributeType.Name == CanBeNullAttributeTypeName);
+        }
     }
 
     public static bool ContainsAllowNullAttribute(this ICustomAttributeProvider definition)
@@ -72,9 +104,9 @@ public static class CecilExtensions
         }
     }
 
-    public static bool MayNotBeNull(this ParameterDefinition arg)
+    public static bool MayNotBeNull(this ParameterDefinition arg, MethodDefinition method, NullGuardMode mode)
     {
-        return !arg.AllowsNull() && !arg.IsOptionalArgumentWithNullDefaultValue() && arg.ParameterType.IsRefType() && !arg.IsOut;
+        return !arg.AllowsNull(method, mode) && !arg.IsOptionalArgumentWithNullDefaultValue() && arg.ParameterType.IsRefType() && !arg.IsOut;
     }
 
     static bool IsOptionalArgumentWithNullDefaultValue(this ParameterDefinition arg)

--- a/Fody/EqualityComparer.cs
+++ b/Fody/EqualityComparer.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+
+using Mono.Cecil;
+
+internal class TypeReferenceEqualityComparer : IEqualityComparer<TypeReference>
+{
+    private TypeReferenceEqualityComparer()
+    {
+    }
+
+    public static IEqualityComparer<TypeReference> Default { get; } = new TypeReferenceEqualityComparer();
+
+    public bool Equals(TypeReference x, TypeReference y)
+    {
+        return GetKey(x) == GetKey(y);
+    }
+
+    public int GetHashCode(TypeReference obj)
+    {
+        return GetKey(obj)?.GetHashCode() ?? 0;
+    }
+
+    private static string GetKey(TypeReference obj)
+    {
+        if (obj == null)
+            return null;
+
+        return GetAssemblyName(obj.Scope) + "|" + obj.FullName;
+    }
+
+    private static string GetAssemblyName(IMetadataScope scope)
+    {
+        if (scope == null)
+            return null;
+
+        if (scope is ModuleDefinition md)
+        {
+            return md.Assembly.FullName;
+        }
+
+        return scope.ToString();
+    }
+}
+
+internal class MemberReferenceEqualityComparer : IEqualityComparer<MemberReference>
+{
+    private MemberReferenceEqualityComparer()
+    {
+    }
+
+    public static IEqualityComparer<MemberReference> Default { get; } = new MemberReferenceEqualityComparer();
+
+    public bool Equals(MemberReference x, MemberReference y)
+    {
+        return GetKey(x) == GetKey(y);
+    }
+
+    public int GetHashCode(MemberReference obj)
+    {
+        return GetKey(obj)?.GetHashCode() ?? 0;
+    }
+
+    private static string GetKey(MemberReference obj)
+    {
+        if (obj == null)
+            return null;
+
+        return GetAssemblyName(obj.DeclaringType.Scope) + "|" + obj.FullName;
+    }
+
+    private static string GetAssemblyName(IMetadataScope scope)
+    {
+        if (scope == null)
+            return null;
+
+        if (scope is ModuleDefinition md)
+        {
+            return md.Assembly.FullName;
+        }
+
+        return scope.ToString();
+    }
+}
+

--- a/Fody/ExplicitMode.cs
+++ b/Fody/ExplicitMode.cs
@@ -413,9 +413,7 @@ internal static class ExplicitMode
 
             if (!_cache.TryGetValue(assemblyName, out var assmblyCache))
             {
-                var moduleFileName = module.FileName;
-
-                assmblyCache = new AssemblyCache(moduleFileName);
+                assmblyCache = new AssemblyCache(module.FileName);
                 _cache.Add(assemblyName, assmblyCache);
             }
 
@@ -431,47 +429,19 @@ internal static class ExplicitMode
             {
                 var externalAnnotations = Path.ChangeExtension(moduleFileName, ".ExternalAnnotations.xml");
 
-                if (File.Exists(externalAnnotations))
+                if (!File.Exists(externalAnnotations))
+                    return;
+
+                try
                 {
                     _externalAnnotations = XDocument.Load(externalAnnotations)
                         .Element("assembly")?
                         .Elements("member")
                         .ToDictionary(member => member.Attribute("name")?.Value);
-
-                    //if (memberName.Length > 2 && memberName[1] == ':')
-                            //{
-                            //    memberType = memberName[0].ToString();
-                            //    memberName = memberName.Substring(2);
-                            //}
-
-                            //MemberNullabilityInfo memberInfo = result.ContainsKey(memberName)
-                            //    ? result[memberName]
-                            //    : new MemberNullabilityInfo(memberType);
-
-                            //foreach (XElement childElement in memberElement.Elements())
-                            //{
-                            //    if (childElement.Name == "parameter")
-                            //    {
-                            //        string parameterName = childElement.Attribute("name")?.Value;
-                            //        if (parameterName != null)
-                            //        {
-                            //            foreach (XElement attributeElement in childElement.Elements("attribute"))
-                            //            {
-                            //                if (ElementHasNullabilityDefinition(attributeElement))
-                            //                {
-                            //                    memberInfo.ParametersNullability[parameterName] = true;
-                            //                }
-                            //            }
-                            //        }
-                            //    }
-                            //    if (childElement.Name == "attribute")
-                            //    {
-                            //        if (ElementHasNullabilityDefinition(childElement))
-                            //        {
-                            //            memberInfo.HasNullabilityDefined = true;
-                            //        }
-                            //    }
-                            //}
+                }
+                catch
+                {
+                    // invalid file, ignore (TODO: log something?)
                 }
             }
 

--- a/Fody/ExplicitMode.cs
+++ b/Fody/ExplicitMode.cs
@@ -1,0 +1,244 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+using Mono.Collections.Generic;
+
+internal static class ExplicitMode
+{
+    private const string NotNullAttributeTypeName = "NotNullAttribute";
+    private const string CanBeNullAttributeTypeName = "CanBeNullAttribute";
+    private const string JetBrainsAnnotationsAssemblyName = "JetBrains.Annotations";
+
+    public static NullGuardMode AutoDetectMode(this ModuleDefinition moduleDefinition)
+    {
+        // If we are referencing JetBrains.Annotations and using NotNull attributes, use explicit mode as default.
+
+        if (moduleDefinition.AssemblyReferences.All(ar => ar.Name != JetBrainsAnnotationsAssemblyName))
+            return NullGuardMode.Implicit;
+
+        foreach (var typeDefinition in moduleDefinition.GetTypes())
+        {
+            foreach (var method in typeDefinition.GetMethods())
+            {
+                if (method.HasNotNullAttribute() || method.Parameters.Any(parameter => parameter.HasNotNullAttribute()))
+                {
+                    return NullGuardMode.Explicit;
+                }
+            }
+
+            if (typeDefinition.Properties.Any(property => property.HasNotNullAttribute()))
+            {
+                return NullGuardMode.Explicit;
+            }
+        }
+
+        return NullGuardMode.Implicit;
+    }
+
+    public static bool AllowsNull(PropertyDefinition property)
+    {
+        if (property.HasNotNullAttribute())
+            return false;
+
+        if (property.HasNotNullAttributeOnImplicitImplementedInterface())
+            return false;
+
+        if (property.EnumerateOverrides().Any(p => !AllowsNull(p)))
+            return false;
+
+        return true;
+    }
+
+    public static bool AllowsNull(ParameterDefinition parameter, MethodDefinition method)
+    {
+        if (parameter.HasNullabilityAnnotation(out var value))
+            return value;
+
+        if (HasNullabilityAnnotationOnImplicitImplementedInterface(parameter, method, out var allowsNull))
+            return allowsNull;
+
+        if (method.EnumerateOverrides().Any(m => !AllowsNull(m.Parameters[parameter.Index], m)))
+            return false;
+
+        return true;
+    }
+
+    public static bool AllowsNull(MethodDefinition method)
+    {
+        if (method.HasNotNullAttribute())
+            return false;
+
+        if (HasNotNullAttributeOnImplicitImplementedInterface(method))
+            return false;
+
+        if (method.EnumerateOverrides().Any(m => !AllowsNull(m)))
+            return false;
+
+        return true;
+    }
+
+    private static bool HasNotNullAttributeOnImplicitImplementedInterface(this PropertyDefinition property)
+    {
+        var declaringType = property.DeclaringType;
+
+        foreach (var interfaceType in declaringType.GetInterfaces())
+        {
+            var interfaceProperty = interfaceType.Properties.Find(property);
+            if (interfaceProperty == null)
+                continue;
+
+            if (declaringType.FindExplicitInterfaceImplementation(interfaceProperty) != null)
+                continue;
+
+            if (interfaceProperty.HasNotNullAttribute())
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasNullabilityAnnotationOnImplicitImplementedInterface(ParameterReference parameter, MethodDefinition method, out bool allowsNull)
+    {
+        allowsNull = true;
+
+        var declaringType = method.DeclaringType;
+        var parameterIndex = parameter.Index;
+
+        foreach (var interfaceType in declaringType.GetInterfaces())
+        {
+            var interfaceMethod = interfaceType.Methods.Find(method);
+            if (interfaceMethod == null)
+                continue;
+
+            if (declaringType.FindExplicitInterfaceImplementation(interfaceMethod) != null)
+                continue;
+
+            if (interfaceMethod.Parameters[parameterIndex].HasNullabilityAnnotation(out allowsNull))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasNotNullAttributeOnImplicitImplementedInterface(MethodDefinition method)
+    {
+        var declaringType = method.DeclaringType;
+
+        foreach (var interfaceType in declaringType.GetInterfaces())
+        {
+            var interfaceMethod = interfaceType.Methods.Find(method);
+            if (interfaceMethod == null)
+                continue;
+
+            if (declaringType.FindExplicitInterfaceImplementation(interfaceMethod) != null)
+                continue;
+
+            if (interfaceMethod.HasNotNullAttribute())
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasNullabilityAnnotation(this ParameterDefinition value, out bool allowsNull)
+    {
+        allowsNull = true;
+
+        if (value == null)
+            return false;
+
+        // Liskov: weakening of preconditions is OK, stop searching for NotNull if parameter is CanBeNull.
+        if (!value.IsOut && value.HasCanBeNullAttribute())
+        {
+            return true;
+        }
+
+        if (value.HasNotNullAttribute())
+        {
+            allowsNull = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasNotNullAttribute(this ICustomAttributeProvider value)
+    {
+        return value?.CustomAttributes.Any(a => a.AttributeType.Name == NotNullAttributeTypeName) ?? false;
+    }
+
+    private static bool HasCanBeNullAttribute(this ICustomAttributeProvider value)
+    {
+        return value?.CustomAttributes.Any(a => a.AttributeType.Name == CanBeNullAttributeTypeName) ?? false;
+    }
+
+    private static IEnumerable<TypeDefinition> GetInterfaces(this TypeDefinition typeDefinition)
+    {
+        if (typeDefinition.IsInterface)
+            yield return typeDefinition;
+
+        foreach (var interfaceType in typeDefinition.Interfaces.Select(i => i.InterfaceType.Resolve()).SelectMany(i => i.GetInterfaces()))
+        {
+            yield return interfaceType;
+        }
+    }
+
+    private static MethodDefinition Find(this Collection<MethodDefinition> methods, MethodReference reference)
+    {
+        return MetadataResolver.GetMethod(methods, reference);
+    }
+
+    private static PropertyDefinition Find(this ICollection<PropertyDefinition> properties, PropertyReference reference)
+    {
+        return properties.FirstOrDefault(property => property.Name == reference.Name
+            && property.PropertyType == reference.PropertyType
+            && property.Parameters.Select(parameter => parameter.ParameterType.Resolve()).SequenceEqual(reference.Parameters.Select(parameter => parameter.ParameterType.Resolve())));
+    }
+
+    private static MethodDefinition FindExplicitInterfaceImplementation(this TypeDefinition type, MethodDefinition interfaceMethod)
+    {
+        return type.Methods.FirstOrDefault(m => m.EnumerateOverrides().Any(o => o == interfaceMethod));
+    }
+
+    private static PropertyDefinition FindExplicitInterfaceImplementation(this TypeDefinition type, PropertyDefinition interfaceProperty)
+    {
+        return type.Properties.FirstOrDefault(p => p.EnumerateOverrides().Any(o => o == interfaceProperty));
+    }
+
+    private static IEnumerable<MethodDefinition> EnumerateOverrides(this MethodDefinition method)
+    {
+        if (method == null)
+            yield break;
+
+        if (method.HasOverrides)
+        {
+            // Explicit interface implementations...
+            foreach (var reference in method.Overrides)
+            {
+                yield return reference.Resolve();
+            }
+        }
+
+        // override of base class method...
+        var baseMethod = method.GetBaseMethod();
+        if (baseMethod != method)
+            yield return baseMethod;
+    }
+
+    private static IEnumerable<PropertyDefinition> EnumerateOverrides(this PropertyDefinition property)
+    {
+        var getMethod = property.GetMethod;
+        foreach (var getOverride in getMethod.EnumerateOverrides())
+        {
+            yield return getOverride.DeclaringType.Properties.FirstOrDefault(p => p.GetMethod == getOverride);
+        }
+
+        var setMethod = property.SetMethod;
+        foreach (var setOverride in setMethod.EnumerateOverrides())
+        {
+            yield return setOverride.DeclaringType.Properties.FirstOrDefault(p => p.SetMethod == setOverride);
+        }
+    }
+}

--- a/Fody/ExplicitMode.cs
+++ b/Fody/ExplicitMode.cs
@@ -42,6 +42,9 @@ internal static class ExplicitMode
         if (property.HasNotNullAttribute())
             return false;
 
+        if (!property.HasThis)
+            return true;
+
         if (property.HasNotNullAttributeOnImplicitImplementedInterface())
             return false;
 
@@ -56,6 +59,9 @@ internal static class ExplicitMode
         if (parameter.HasNullabilityAnnotation(out var value))
             return value;
 
+        if (!method.HasThis)
+            return true;
+
         if (HasNullabilityAnnotationOnImplicitImplementedInterface(parameter, method, out var allowsNull))
             return allowsNull;
 
@@ -69,6 +75,9 @@ internal static class ExplicitMode
     {
         if (method.HasNotNullAttribute())
             return false;
+
+        if (!method.HasThis)
+            return true;
 
         if (HasNotNullAttributeOnImplicitImplementedInterface(method))
             return false;

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -24,6 +24,8 @@
     <Copy SourceFiles="$(OutputPath)NullGuard.Fody.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\netstandard1.0\NullGuard.dll" DestinationFolder="$(SolutionDir)NuGetBuild\lib\netstandard1.0" />
     <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\netstandard1.0\NullGuard.xml" DestinationFolder="$(SolutionDir)NuGetBuild\lib\netstandard1.0" />
+    <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\portable40-net40+sl5+win8+wp8+wpa81\NullGuard.dll" DestinationFolder="$(SolutionDir)NuGetBuild\lib\portable40-net40+sl5+win8+wp8+wpa81" />
+    <Copy SourceFiles="$(SolutionDir)ReferenceAssembly\bin\$(ConfigurationName)\portable40-net40+sl5+win8+wp8+wpa81\NullGuard.xml" DestinationFolder="$(SolutionDir)NuGetBuild\lib\portable40-net40+sl5+win8+wp8+wpa81" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(OutputPath)NullGuard.Fody.dll" />
   </Target>
 </Project>

--- a/Fody/MethodProcessor.cs
+++ b/Fody/MethodProcessor.cs
@@ -72,7 +72,7 @@ public partial class ModuleWeaver
             }
 
             if (localValidationFlags.HasFlag(ValidationFlags.ReturnValues) &&
-                !method.AllowsNullReturnValue() &&
+                !method.AllowsNullReturnValue(nullGuardMode) &&
                 returnType.IsRefType() &&
                 returnType.FullName != typeof(void).FullName)
             {
@@ -91,7 +91,7 @@ public partial class ModuleWeaver
 
         foreach (var parameter in method.Parameters.Reverse())
         {
-            if (!parameter.MayNotBeNull())
+            if (!parameter.MayNotBeNull(method, nullGuardMode))
             {
                 continue;
             }
@@ -147,7 +147,7 @@ public partial class ModuleWeaver
         foreach (var ret in returnPoints)
         {
             if (localValidationFlags.HasFlag(ValidationFlags.ReturnValues) &&
-                !method.AllowsNullReturnValue() &&
+                !method.AllowsNullReturnValue(nullGuardMode) &&
                 method.ReturnType.IsRefType() &&
                 method.ReturnType.FullName != typeof(void).FullName &&
                 !method.IsGetter)
@@ -166,7 +166,7 @@ public partial class ModuleWeaver
                     if (localValidationFlags.HasFlag(ValidationFlags.OutValues) &&
                         parameter.IsOut &&
                         parameter.ParameterType.IsRefType() &&
-                        !parameter.AllowsNull())
+                        !parameter.AllowsNull(method, nullGuardMode))
                     {
                         var errorMessage = $"[NullGuard] Out parameter '{parameter.Name}' is null.";
 

--- a/Fody/NullGuardMode.cs
+++ b/Fody/NullGuardMode.cs
@@ -1,0 +1,12 @@
+﻿public enum NullGuardMode
+{
+    AutoDetect,
+    /// <summary>
+    /// Not null is implicit, allow null must be set explicit.
+    /// </summary>
+    Implicit,
+    /// <summary>
+    /// Not null must be set explicit, allow null is implicit.
+    /// </summary>
+    Explicit
+}

--- a/Fody/PropertyProcessor.cs
+++ b/Fody/PropertyProcessor.cs
@@ -46,7 +46,7 @@ public partial class ModuleWeaver
             return;
         }
 
-        if (property.AllowsNull())
+        if (property.AllowsNull(nullGuardMode))
         {
             return;
         }
@@ -62,7 +62,7 @@ public partial class ModuleWeaver
             if ((localValidationFlags.HasFlag(ValidationFlags.NonPublic) ||
                 property.GetMethod.IsPublic &&
                 property.DeclaringType.IsPublicOrNestedPublic()) &&
-                !property.GetMethod.MethodReturnType.AllowsNull()
+                !property.GetMethod.MethodReturnType.ImplicitAllowsNull()
                )
             {
                 InjectPropertyGetterGuard(getMethod, doc, property);
@@ -139,7 +139,7 @@ public partial class ModuleWeaver
     {
         var valueParameter = property.SetMethod.GetPropertySetterValueParameter();
 
-        if (!valueParameter.MayNotBeNull())
+        if (!valueParameter.MayNotBeNull(setMethod, NullGuardMode.Implicit))
             return;
 
         var guardInstructions = new List<Instruction>();

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -1,14 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 14.0.22823.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fody", "Fody\Fody.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0} = {B5AEB0E8-28F4-4955-A055-9C200F7113F0}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{5A86453B-96FB-4B6E-A283-225BB9F753D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{5A86453B-96FB-4B6E-A283-225BB9F753D3}"
 	ProjectSection(ProjectDependencies) = postProject
 		{23C29B37-221D-473E-967B-DC423F5F4AB2} = {23C29B37-221D-473E-967B-DC423F5F4AB2}
 	EndProjectSection
@@ -17,38 +17,45 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyToProcess", "Assemb
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferenceAssembly", "ReferenceAssembly\ReferenceAssembly.csproj", "{B5AEB0E8-28F4-4955-A055-9C200F7113F0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyToProcessExplicit", "AssemblyToProcessExplicit\AssemblyToProcessExplicit.csproj", "{829F9B12-5087-4DDB-9ECF-237F691DAEC2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestsExplicit", "TestsExplicit\TestsExplicit.csproj", "{7F75DAD1-A440-4B15-AE42-34EAEB515A05}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{80736054-409A-49E0-A30F-44530D83166C}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|x86.ActiveCfg = Release|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{23C29B37-221D-473E-967B-DC423F5F4AB2}.Release|x86.ActiveCfg = Release|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B5AEB0E8-28F4-4955-A055-9C200F7113F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{829F9B12-5087-4DDB-9ECF-237F691DAEC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{829F9B12-5087-4DDB-9ECF-237F691DAEC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{829F9B12-5087-4DDB-9ECF-237F691DAEC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{829F9B12-5087-4DDB-9ECF-237F691DAEC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -26,6 +26,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithAnnotations", "AssemblyWithAnnotations\AssemblyWithAnnotations.csproj", "{E6300522-9050-43C0-8B29-9993E26415FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithExternalAnnotations", "AssemblyWithExternalAnnotations\AssemblyWithExternalAnnotations.csproj", "{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +60,14 @@ Global
 		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F75DAD1-A440-4B15-AE42-34EAEB515A05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6300522-9050-43C0-8B29-9993E26415FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6300522-9050-43C0-8B29-9993E26415FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6300522-9050-43C0-8B29-9993E26415FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6300522-9050-43C0-8B29-9993E26415FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ReferenceAssembly/ReferenceAssembly.csproj
+++ b/ReferenceAssembly/ReferenceAssembly.csproj
@@ -1,12 +1,24 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;portable40-net40+sl5+win8+wp8+wpa81</TargetFrameworks>
     <AssemblyName>NullGuard</AssemblyName>
     <RootNamespace>NullGuard</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81'">
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='portable40-net40+sl5+win8+wp8+wpa81'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>  
 
 </Project>

--- a/TestsExplicit/ApprovalTestConfig.cs
+++ b/TestsExplicit/ApprovalTestConfig.cs
@@ -1,0 +1,3 @@
+﻿using ApprovalTests.Reporters;
+
+[assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]

--- a/TestsExplicit/ApprovedTests.ClassWithBadAttributes.approved.txt
+++ b/TestsExplicit/ApprovedTests.ClassWithBadAttributes.approved.txt
@@ -1,0 +1,43 @@
+﻿.class public abstract auto ansi beforefieldinit ClassWithBadAttributes
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig newslot abstract virtual 
+          instance void  MethodWithNoNullCheckOnParam(string arg) cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance string  get_PropertyWithNoNullCheckOnSet() cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance void  set_PropertyWithNoNullCheckOnSet(string 'value') cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance string  get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance void  set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
+  {
+  } 
+  .method public hidebysig newslot abstract virtual 
+          instance string  MethodAllowsNullReturnValue() cil managed
+  {
+  } 
+  .method family hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string PropertyWithNoNullCheckOnSet()
+  {
+  } 
+  .property instance string PropertyAllowsNullGetButDoesNotAllowNullSet()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.ClassWithPrivateMethod.approved.txt
+++ b/TestsExplicit/ApprovedTests.ClassWithPrivateMethod.approved.txt
@@ -7,7 +7,6 @@
   {
     // Code size       8 (0x8)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  ldnull
     IL_0002:  call       instance void ClassWithPrivateMethod::SomePrivateMethod(string)

--- a/TestsExplicit/ApprovedTests.ClassWithPrivateMethod.approved.txt
+++ b/TestsExplicit/ApprovedTests.ClassWithPrivateMethod.approved.txt
@@ -1,0 +1,62 @@
+﻿.class public auto ansi beforefieldinit ClassWithPrivateMethod
+       extends [mscorlib]System.Object
+{
+  .field private string '<SomeProperty>k__BackingField'
+  .method public hidebysig instance void 
+          PublicWrapperOfPrivateMethod() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  ldnull
+    IL_0002:  call       instance void ClassWithPrivateMethod::SomePrivateMethod(string)
+    IL_0007:  ret
+  } 
+  .method private hidebysig instance void 
+          SomePrivateMethod(string x) cil managed
+  {
+    .param [1]
+    // Code size       20 (0x14)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "x"
+    IL_0008:  ldstr      "[NullGuard] x is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_SomeProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string ClassWithPrivateMethod::'<SomeProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_SomeProperty(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string ClassWithPrivateMethod::'<SomeProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string SomeProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
+++ b/TestsExplicit/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
@@ -7,7 +7,6 @@
   {
     // Code size       8 (0x8)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  ldnull
     IL_0002:  call       instance void ClassWithPrivateMethod::SomePrivateMethod(string)

--- a/TestsExplicit/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
+++ b/TestsExplicit/ApprovedTests.ClassWithPrivateMethodNoAssert.approved.txt
@@ -1,0 +1,62 @@
+﻿.class public auto ansi beforefieldinit ClassWithPrivateMethod
+       extends [mscorlib]System.Object
+{
+  .field private string '<SomeProperty>k__BackingField'
+  .method public hidebysig instance void 
+          PublicWrapperOfPrivateMethod() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  ldnull
+    IL_0002:  call       instance void ClassWithPrivateMethod::SomePrivateMethod(string)
+    IL_0007:  ret
+  } 
+  .method private hidebysig instance void 
+          SomePrivateMethod(string x) cil managed
+  {
+    .param [1]
+    // Code size       20 (0x14)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "x"
+    IL_0008:  ldstr      "[NullGuard] x is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_SomeProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string ClassWithPrivateMethod::'<SomeProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_SomeProperty(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string ClassWithPrivateMethod::'<SomeProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string SomeProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
@@ -8,7 +8,6 @@
   {
     // Code size       20 (0x14)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.2
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "arg"

--- a/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
@@ -27,7 +27,8 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "DerivedClass::MethodWithNotNullReturnValue(System.String)' is null."
+    + "DerivedClass::MethodWithNotNullReturnValue(System.String)'"
+    + " is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret

--- a/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.DerivedClass.approved.txt
@@ -1,0 +1,82 @@
+﻿.class public auto ansi beforefieldinit DerivedClass
+       extends BaseClassWithAttributes
+{
+  .field private string '<NotNullProperty>k__BackingField'
+  .method public hidebysig virtual instance void 
+          MethodWithNotNullParameter(string canBeNull,
+                                     string arg) cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.2
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "arg"
+    IL_0008:  ldstr      "[NullGuard] arg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig virtual instance string 
+          MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  dup
+    IL_0002:  brtrue.s   IL_0010
+    IL_0004:  pop
+    IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "DerivedClass::MethodWithNotNullReturnValue(System.String)' is null."
+    IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_000f:  throw
+    IL_0010:  ret
+  } 
+  .method public hidebysig specialname virtual 
+          instance string  get_NotNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string DerivedClass::'<NotNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g DerivedClass::NotNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname virtual 
+          instance void  set_NotNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String DerivedClass::NotNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string DerivedClass::'<NotNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void BaseClassWithAttributes::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string NotNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.DerivedClassAssemblyBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.DerivedClassAssemblyBase.approved.txt
@@ -1,12 +1,10 @@
-﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
-       extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+﻿.class public auto ansi beforefieldinit DerivedClass
+       extends [AssemblyWithAnnotations]AssemblyWithAnnotations.BaseClassWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
-  .method public hidebysig newslot virtual final 
-          instance void  MethodWithNotNullParameter(string canBeNull,
-                                                    string arg) cil managed
+  .method public hidebysig virtual instance void 
+          MethodWithNotNullParameter(string canBeNull,
+                                     string arg) cil managed
   {
     // Code size       20 (0x14)
     .maxstack  2
@@ -19,8 +17,8 @@
     IL_0012:  throw
     IL_0013:  ret
   } 
-  .method public hidebysig newslot virtual final 
-          instance string  MethodWithNotNullReturnValue(string arg) cil managed
+  .method public hidebysig virtual instance string 
+          MethodWithNotNullReturnValue(string arg) cil managed
   {
     // Code size       17 (0x11)
     .maxstack  2
@@ -29,29 +27,29 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInheritedInterface::MethodWithNotNullReturnValue"
-    + "(System.String)' is null."
+    + "DerivedClass::MethodWithNotNullReturnValue(System.String)'"
+    + " is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
   } 
-  .method public hidebysig newslot specialname virtual final 
+  .method public hidebysig specialname virtual 
           instance string  get_NotNullProperty() cil managed
   {
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string DerivedClass::'<NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInheritedInterface::NotNullProperty()' is null."
+    + "g DerivedClass::NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
   } 
-  .method public hidebysig newslot specialname virtual final 
+  .method public hidebysig specialname virtual 
           instance void  set_NotNullProperty(string 'value') cil managed
   {
     // Code size       27 (0x1b)
@@ -60,14 +58,13 @@
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInheritedInterface::NotNullProperty()'"
-    + " to null."
+    + "em.String DerivedClass::NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string DerivedClass::'<NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 
@@ -76,7 +73,7 @@
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [AssemblyWithAnnotations]AssemblyWithAnnotations.BaseClassWithAttributes::.ctor()
     IL_0006:  ret
   } 
   .property instance string NotNullProperty()

--- a/TestsExplicit/ApprovedTests.DerivedClassExternalBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.DerivedClassExternalBase.approved.txt
@@ -1,12 +1,10 @@
-﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
-       extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+﻿.class public auto ansi beforefieldinit DerivedClass
+       extends [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.BaseClassWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
-  .method public hidebysig newslot virtual final 
-          instance void  MethodWithNotNullParameter(string canBeNull,
-                                                    string arg) cil managed
+  .method public hidebysig virtual instance void 
+          MethodWithNotNullParameter(string canBeNull,
+                                     string arg) cil managed
   {
     // Code size       20 (0x14)
     .maxstack  2
@@ -19,8 +17,8 @@
     IL_0012:  throw
     IL_0013:  ret
   } 
-  .method public hidebysig newslot virtual final 
-          instance string  MethodWithNotNullReturnValue(string arg) cil managed
+  .method public hidebysig virtual instance string 
+          MethodWithNotNullReturnValue(string arg) cil managed
   {
     // Code size       17 (0x11)
     .maxstack  2
@@ -29,29 +27,29 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInheritedInterface::MethodWithNotNullReturnValue"
-    + "(System.String)' is null."
+    + "DerivedClass::MethodWithNotNullReturnValue(System.String)'"
+    + " is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
   } 
-  .method public hidebysig newslot specialname virtual final 
+  .method public hidebysig specialname virtual 
           instance string  get_NotNullProperty() cil managed
   {
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string DerivedClass::'<NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInheritedInterface::NotNullProperty()' is null."
+    + "g DerivedClass::NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
   } 
-  .method public hidebysig newslot specialname virtual final 
+  .method public hidebysig specialname virtual 
           instance void  set_NotNullProperty(string 'value') cil managed
   {
     // Code size       27 (0x1b)
@@ -60,14 +58,13 @@
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInheritedInterface::NotNullProperty()'"
-    + " to null."
+    + "em.String DerivedClass::NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string DerivedClass::'<NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 
@@ -76,7 +73,7 @@
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.BaseClassWithAttributes::.ctor()
     IL_0006:  ret
   } 
   .property instance string NotNullProperty()

--- a/TestsExplicit/ApprovedTests.ErrorsList.approved.txt
+++ b/TestsExplicit/ApprovedTests.ErrorsList.approved.txt
@@ -1,0 +1,3 @@
+﻿Errors: [0] = Method 'System.Void ClassWithBadAttributes::MethodWithNoNullCheckOnParam(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.
+Errors: [1] = Method 'System.Void ClassWithBadAttributes::set_PropertyWithNoNullCheckOnSet(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.
+Errors: [2] = Method 'System.Void InterfaceBadAttributes::set_PropertyWithNoNullCheckOnSet(System.String)' is abstract but has a [AllowNullAttribute]. Remove this attribute.

--- a/TestsExplicit/ApprovedTests.ExplicitMode.approved.txt
+++ b/TestsExplicit/ApprovedTests.ExplicitMode.approved.txt
@@ -1,0 +1,82 @@
+﻿.class public auto ansi beforefieldinit DerivedClass
+       extends BaseClassWithAttributes
+{
+  .field private string '<NotNullProperty>k__BackingField'
+  .method public hidebysig virtual instance void 
+          MethodWithNotNullParameter(string canBeNull,
+                                     string arg) cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.2
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "arg"
+    IL_0008:  ldstr      "[NullGuard] arg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig virtual instance string 
+          MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  dup
+    IL_0002:  brtrue.s   IL_0010
+    IL_0004:  pop
+    IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "DerivedClass::MethodWithNotNullReturnValue(System.String)' is null."
+    IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_000f:  throw
+    IL_0010:  ret
+  } 
+  .method public hidebysig specialname virtual 
+          instance string  get_NotNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string DerivedClass::'<NotNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g DerivedClass::NotNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname virtual 
+          instance void  set_NotNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String DerivedClass::NotNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string DerivedClass::'<NotNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void BaseClassWithAttributes::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string NotNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.GenericClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.GenericClass.approved.txt
@@ -1,0 +1,54 @@
+﻿.class public auto ansi beforefieldinit GenericClass`1<T>
+       extends [mscorlib]System.Object
+{
+  .field private !T '<NonNullProperty>k__BackingField'
+  .method public hidebysig specialname instance !T 
+          get_NonNullProperty() cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      !0 class GenericClass`1<!T>::'<NonNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  box        !T
+    IL_000c:  brtrue.s   IL_001a
+    IL_000e:  pop
+    IL_000f:  ldstr      "[NullGuard] Return value of property 'T GenericCla"
+    + "ss`1::NonNullProperty()' is null."
+    IL_0014:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0019:  throw
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NonNullProperty(!T 'value') cil managed
+  {
+    // Code size       32 (0x20)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  box        !T
+    IL_0006:  brtrue.s   IL_0018
+    IL_0008:  ldstr      "value"
+    IL_000d:  ldstr      "[NullGuard] Cannot set the value of property 'T Ge"
+    + "nericClass`1::NonNullProperty()' to null."
+    IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0017:  throw
+    IL_0018:  ldarg.0
+    IL_0019:  ldarg.1
+    IL_001a:  stfld      !0 class GenericClass`1<!T>::'<NonNullProperty>k__BackingField'
+    IL_001f:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance !T NonNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.GenericClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.GenericClass.approved.txt
@@ -7,7 +7,6 @@
   {
     // Code size       27 (0x1b)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  ldfld      !0 class GenericClass`1<!T>::'<NonNullProperty>k__BackingField'
     IL_0006:  dup

--- a/TestsExplicit/ApprovedTests.ImplementsInheritedInterface.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInheritedInterface.approved.txt
@@ -1,0 +1,85 @@
+﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
+       extends [mscorlib]System.Object
+       implements InheritedInterface,
+                  BaseInterfaceWithAttributes
+{
+  .field private string '<NotNullProperty>k__BackingField'
+  .method public hidebysig newslot virtual final 
+          instance void  MethodWithNotNullParameter(string canBeNull,
+                                                    string arg) cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.2
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "arg"
+    IL_0008:  ldstr      "[NullGuard] arg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig newslot virtual final 
+          instance string  MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  dup
+    IL_0002:  brtrue.s   IL_0010
+    IL_0004:  pop
+    IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "ImplementsInheritedInterface::MethodWithNotNullReturnValue(System.Strin"
+    + "g)' is null."
+    IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_000f:  throw
+    IL_0010:  ret
+  } 
+  .method public hidebysig newslot specialname virtual final 
+          instance string  get_NotNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g ImplementsInheritedInterface::NotNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig newslot specialname virtual final 
+          instance void  set_NotNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String ImplementsInheritedInterface::NotNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string NotNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.ImplementsInheritedInterface.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInheritedInterface.approved.txt
@@ -10,7 +10,6 @@
   {
     // Code size       20 (0x14)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.2
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "arg"

--- a/TestsExplicit/ApprovedTests.ImplementsInheritedInterfaceAssemblyBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInheritedInterfaceAssemblyBase.approved.txt
@@ -1,7 +1,7 @@
 ﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
        extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+       implements [AssemblyWithAnnotations]AssemblyWithAnnotations.InheritedInterface,
+                  [AssemblyWithAnnotations]AssemblyWithAnnotations.BaseInterfaceWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
   .method public hidebysig newslot virtual final 

--- a/TestsExplicit/ApprovedTests.ImplementsInheritedInterfaceExternalBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInheritedInterfaceExternalBase.approved.txt
@@ -1,7 +1,7 @@
 ﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
        extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+       implements [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InheritedInterface,
+                  [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.BaseInterfaceWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
   .method public hidebysig newslot virtual final 

--- a/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
@@ -28,8 +28,8 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInterface::MethodWithNotNullReturnValue(System.String)' is nu"
-    + "ll."
+    + "ImplementsInterface::MethodWithNotNullReturnValue(System.S"
+    + "tring)' is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret

--- a/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
@@ -1,0 +1,84 @@
+﻿.class public auto ansi beforefieldinit ImplementsInterface
+       extends [mscorlib]System.Object
+       implements InterfaceWithAttributes
+{
+  .field private string '<NotNullProperty>k__BackingField'
+  .method public hidebysig newslot virtual final 
+          instance void  MethodWithNotNullParameter(string canBeNull,
+                                                    string arg) cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.2
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "arg"
+    IL_0008:  ldstr      "[NullGuard] arg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig newslot virtual final 
+          instance string  MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  dup
+    IL_0002:  brtrue.s   IL_0010
+    IL_0004:  pop
+    IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "ImplementsInterface::MethodWithNotNullReturnValue(System.String)' is nu"
+    + "ll."
+    IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_000f:  throw
+    IL_0010:  ret
+  } 
+  .method public hidebysig newslot specialname virtual final 
+          instance string  get_NotNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g ImplementsInterface::NotNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig newslot specialname virtual final 
+          instance void  set_NotNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String ImplementsInterface::NotNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string NotNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterface.approved.txt
@@ -9,7 +9,6 @@
   {
     // Code size       20 (0x14)
     .maxstack  2
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.2
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "arg"

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceAssemblyBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceAssemblyBase.approved.txt
@@ -1,7 +1,6 @@
-﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
+﻿.class public auto ansi beforefieldinit ImplementsInterface
        extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+       implements [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
   .method public hidebysig newslot virtual final 
@@ -29,8 +28,8 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInheritedInterface::MethodWithNotNullReturnValue"
-    + "(System.String)' is null."
+    + "ImplementsInterface::MethodWithNotNullReturnValue(System.S"
+    + "tring)' is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
@@ -41,12 +40,12 @@
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInheritedInterface::NotNullProperty()' is null."
+    + "g ImplementsInterface::NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
@@ -60,14 +59,13 @@
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInheritedInterface::NotNullProperty()'"
-    + " to null."
+    + "em.String ImplementsInterface::NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicit.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicit.approved.txt
@@ -9,7 +9,6 @@
   {
     // Code size       9 (0x9)
     .maxstack  3
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicit.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicit.approved.txt
@@ -1,0 +1,135 @@
+﻿.class public auto ansi beforefieldinit ImplementsInterfaceExplicit
+       extends [mscorlib]System.Object
+       implements InterfaceWithAttributes
+{
+  .field private string '<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+  .method public hidebysig instance void 
+          MethodWithNotNullParameter(string canBeNull,
+                                     string arg) cil managed
+  {
+    // Code size       9 (0x9)
+    .maxstack  3
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  ldarg.2
+    IL_0003:  callvirt   instance void InterfaceWithAttributes::MethodWithNotNullParameter(string,
+                                                                                           string)
+    IL_0008:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  callvirt   instance string InterfaceWithAttributes::MethodWithNotNullReturnValue(string)
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_NotNullProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  callvirt   instance string InterfaceWithAttributes::get_NotNullProperty()
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NotNullProperty(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  callvirt   instance void InterfaceWithAttributes::set_NotNullProperty(string)
+    IL_0007:  ret
+  } 
+  .method private hidebysig newslot virtual final 
+          instance void  InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull,
+                                                                            string arg) cil managed
+  {
+    .override InterfaceWithAttributes::MethodWithNotNullParameter
+    // Code size       20 (0x14)
+    .maxstack  2
+    IL_0000:  ldarg.2
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "arg"
+    IL_0008:  ldstr      "[NullGuard] arg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method private hidebysig newslot virtual final 
+          instance string  InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg) cil managed
+  {
+    .override InterfaceWithAttributes::MethodWithNotNullReturnValue
+    // Code size       17 (0x11)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  dup
+    IL_0002:  brtrue.s   IL_0010
+    IL_0004:  pop
+    IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "ImplementsInterfaceExplicit::InterfaceWithAttributes.MethodWithNotNullR"
+    + "eturnValue(System.String)' is null."
+    IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_000f:  throw
+    IL_0010:  ret
+  } 
+  .method private hidebysig newslot specialname virtual final 
+          instance string  InterfaceWithAttributes.get_NotNullProperty() cil managed
+  {
+    .override InterfaceWithAttributes::get_NotNullProperty
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g ImplementsInterfaceExplicit::InterfaceWithAttributes.NotNullProperty("
+    + ")' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method private hidebysig newslot specialname virtual final 
+          instance void  InterfaceWithAttributes.set_NotNullProperty(string 'value') cil managed
+  {
+    .override InterfaceWithAttributes::set_NotNullProperty
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String ImplementsInterfaceExplicit::InterfaceWithAttributes.NotNullP"
+    + "roperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance string NotNullProperty()
+  {
+  } 
+  .property instance string InterfaceWithAttributes.NotNullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicitAssemblyBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicitAssemblyBase.approved.txt
@@ -1,8 +1,8 @@
 ﻿.class public auto ansi beforefieldinit ImplementsInterfaceExplicit
        extends [mscorlib]System.Object
-       implements InterfaceWithAttributes
+       implements [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes
 {
-  .field private string '<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+  .field private string '<AssemblyWithAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
   .method public hidebysig instance void 
           MethodWithNotNullParameter(string canBeNull,
                                      string arg) cil managed
@@ -12,8 +12,8 @@
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2
-    IL_0003:  callvirt   instance void InterfaceWithAttributes::MethodWithNotNullParameter(string,
-                                                                                           string)
+    IL_0003:  callvirt   instance void [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::MethodWithNotNullParameter(string,
+                                                                                                                                            string)
     IL_0008:  ret
   } 
   .method public hidebysig instance string 
@@ -23,7 +23,7 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  callvirt   instance string InterfaceWithAttributes::MethodWithNotNullReturnValue(string)
+    IL_0002:  callvirt   instance string [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::MethodWithNotNullReturnValue(string)
     IL_0007:  ret
   } 
   .method public hidebysig specialname instance string 
@@ -32,7 +32,7 @@
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
-    IL_0001:  callvirt   instance string InterfaceWithAttributes::get_NotNullProperty()
+    IL_0001:  callvirt   instance string [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::get_NotNullProperty()
     IL_0006:  ret
   } 
   .method public hidebysig specialname instance void 
@@ -42,14 +42,14 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  callvirt   instance void InterfaceWithAttributes::set_NotNullProperty(string)
+    IL_0002:  callvirt   instance void [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::set_NotNullProperty(string)
     IL_0007:  ret
   } 
   .method private hidebysig newslot virtual final 
-          instance void  InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull,
-                                                                            string arg) cil managed
+          instance void  AssemblyWithAnnotations.InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull,
+                                                                                                    string arg) cil managed
   {
-    .override InterfaceWithAttributes::MethodWithNotNullParameter
+    .override [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::MethodWithNotNullParameter
     // Code size       20 (0x14)
     .maxstack  2
     IL_0000:  ldarg.2
@@ -62,9 +62,9 @@
     IL_0013:  ret
   } 
   .method private hidebysig newslot virtual final 
-          instance string  InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg) cil managed
+          instance string  AssemblyWithAnnotations.InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg) cil managed
   {
-    .override InterfaceWithAttributes::MethodWithNotNullReturnValue
+    .override [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::MethodWithNotNullReturnValue
     // Code size       17 (0x11)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -72,48 +72,48 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInterfaceExplicit::InterfaceWithAttributes.Metho"
-    + "dWithNotNullReturnValue(System.String)' is null."
+    + "ImplementsInterfaceExplicit::AssemblyWithAnnotations.Inter"
+    + "faceWithAttributes.MethodWithNotNullReturnValue(System.String)' is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
   } 
   .method private hidebysig newslot specialname virtual final 
-          instance string  InterfaceWithAttributes.get_NotNullProperty() cil managed
+          instance string  AssemblyWithAnnotations.InterfaceWithAttributes.get_NotNullProperty() cil managed
   {
-    .override InterfaceWithAttributes::get_NotNullProperty
+    .override [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::get_NotNullProperty
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string ImplementsInterfaceExplicit::'<AssemblyWithAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInterfaceExplicit::InterfaceWithAttributes.Not"
-    + "NullProperty()' is null."
+    + "g ImplementsInterfaceExplicit::AssemblyWithAnnotations.Int"
+    + "erfaceWithAttributes.NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
   } 
   .method private hidebysig newslot specialname virtual final 
-          instance void  InterfaceWithAttributes.set_NotNullProperty(string 'value') cil managed
+          instance void  AssemblyWithAnnotations.InterfaceWithAttributes.set_NotNullProperty(string 'value') cil managed
   {
-    .override InterfaceWithAttributes::set_NotNullProperty
+    .override [AssemblyWithAnnotations]AssemblyWithAnnotations.InterfaceWithAttributes::set_NotNullProperty
     // Code size       27 (0x1b)
     .maxstack  2
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInterfaceExplicit::InterfaceWithAttrib"
-    + "utes.NotNullProperty()' to null."
+    + "em.String ImplementsInterfaceExplicit::AssemblyWithAnnotat"
+    + "ions.InterfaceWithAttributes.NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string ImplementsInterfaceExplicit::'<AssemblyWithAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 
@@ -128,7 +128,7 @@
   .property instance string NotNullProperty()
   {
   } 
-  .property instance string InterfaceWithAttributes.NotNullProperty()
+  .property instance string AssemblyWithAnnotations.InterfaceWithAttributes.NotNullProperty()
   {
   } 
 }

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicitExternalBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceExplicitExternalBase.approved.txt
@@ -1,8 +1,8 @@
 ﻿.class public auto ansi beforefieldinit ImplementsInterfaceExplicit
        extends [mscorlib]System.Object
-       implements InterfaceWithAttributes
+       implements [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes
 {
-  .field private string '<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+  .field private string '<AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
   .method public hidebysig instance void 
           MethodWithNotNullParameter(string canBeNull,
                                      string arg) cil managed
@@ -12,8 +12,8 @@
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2
-    IL_0003:  callvirt   instance void InterfaceWithAttributes::MethodWithNotNullParameter(string,
-                                                                                           string)
+    IL_0003:  callvirt   instance void [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::MethodWithNotNullParameter(string,
+                                                                                                                                                            string)
     IL_0008:  ret
   } 
   .method public hidebysig instance string 
@@ -23,7 +23,7 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  callvirt   instance string InterfaceWithAttributes::MethodWithNotNullReturnValue(string)
+    IL_0002:  callvirt   instance string [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::MethodWithNotNullReturnValue(string)
     IL_0007:  ret
   } 
   .method public hidebysig specialname instance string 
@@ -32,7 +32,7 @@
     // Code size       7 (0x7)
     .maxstack  1
     IL_0000:  ldarg.0
-    IL_0001:  callvirt   instance string InterfaceWithAttributes::get_NotNullProperty()
+    IL_0001:  callvirt   instance string [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::get_NotNullProperty()
     IL_0006:  ret
   } 
   .method public hidebysig specialname instance void 
@@ -42,14 +42,14 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  callvirt   instance void InterfaceWithAttributes::set_NotNullProperty(string)
+    IL_0002:  callvirt   instance void [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::set_NotNullProperty(string)
     IL_0007:  ret
   } 
   .method private hidebysig newslot virtual final 
-          instance void  InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull,
-                                                                            string arg) cil managed
+          instance void  AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullParameter(string canBeNull,
+                                                                                                            string arg) cil managed
   {
-    .override InterfaceWithAttributes::MethodWithNotNullParameter
+    .override [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::MethodWithNotNullParameter
     // Code size       20 (0x14)
     .maxstack  2
     IL_0000:  ldarg.2
@@ -62,9 +62,9 @@
     IL_0013:  ret
   } 
   .method private hidebysig newslot virtual final 
-          instance string  InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg) cil managed
+          instance string  AssemblyWithExternalAnnotations.InterfaceWithAttributes.MethodWithNotNullReturnValue(string arg) cil managed
   {
-    .override InterfaceWithAttributes::MethodWithNotNullReturnValue
+    .override [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::MethodWithNotNullReturnValue
     // Code size       17 (0x11)
     .maxstack  2
     IL_0000:  ldarg.1
@@ -72,48 +72,49 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInterfaceExplicit::InterfaceWithAttributes.Metho"
-    + "dWithNotNullReturnValue(System.String)' is null."
+    + "ImplementsInterfaceExplicit::AssemblyWithExternalAnnotatio"
+    + "ns.InterfaceWithAttributes.MethodWithNotNullReturnValue(System.String)'"
+    + " is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
   } 
   .method private hidebysig newslot specialname virtual final 
-          instance string  InterfaceWithAttributes.get_NotNullProperty() cil managed
+          instance string  AssemblyWithExternalAnnotations.InterfaceWithAttributes.get_NotNullProperty() cil managed
   {
-    .override InterfaceWithAttributes::get_NotNullProperty
+    .override [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::get_NotNullProperty
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string ImplementsInterfaceExplicit::'<AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInterfaceExplicit::InterfaceWithAttributes.Not"
-    + "NullProperty()' is null."
+    + "g ImplementsInterfaceExplicit::AssemblyWithExternalAnnotat"
+    + "ions.InterfaceWithAttributes.NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
   } 
   .method private hidebysig newslot specialname virtual final 
-          instance void  InterfaceWithAttributes.set_NotNullProperty(string 'value') cil managed
+          instance void  AssemblyWithExternalAnnotations.InterfaceWithAttributes.set_NotNullProperty(string 'value') cil managed
   {
-    .override InterfaceWithAttributes::set_NotNullProperty
+    .override [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes::set_NotNullProperty
     // Code size       27 (0x1b)
     .maxstack  2
     IL_0000:  ldarg.1
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInterfaceExplicit::InterfaceWithAttrib"
-    + "utes.NotNullProperty()' to null."
+    + "em.String ImplementsInterfaceExplicit::AssemblyWithExterna"
+    + "lAnnotations.InterfaceWithAttributes.NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInterfaceExplicit::'<InterfaceWithAttributes.NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string ImplementsInterfaceExplicit::'<AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 
@@ -128,7 +129,7 @@
   .property instance string NotNullProperty()
   {
   } 
-  .property instance string InterfaceWithAttributes.NotNullProperty()
+  .property instance string AssemblyWithExternalAnnotations.InterfaceWithAttributes.NotNullProperty()
   {
   } 
 }

--- a/TestsExplicit/ApprovedTests.ImplementsInterfaceExternalBase.approved.txt
+++ b/TestsExplicit/ApprovedTests.ImplementsInterfaceExternalBase.approved.txt
@@ -1,7 +1,6 @@
-﻿.class public auto ansi beforefieldinit ImplementsInheritedInterface
+﻿.class public auto ansi beforefieldinit ImplementsInterface
        extends [mscorlib]System.Object
-       implements InheritedInterface,
-                  BaseInterfaceWithAttributes
+       implements [AssemblyWithExternalAnnotations]AssemblyWithExternalAnnotations.InterfaceWithAttributes
 {
   .field private string '<NotNullProperty>k__BackingField'
   .method public hidebysig newslot virtual final 
@@ -29,8 +28,8 @@
     IL_0002:  brtrue.s   IL_0010
     IL_0004:  pop
     IL_0005:  ldstr      "[NullGuard] Return value of method 'System.String "
-    + "ImplementsInheritedInterface::MethodWithNotNullReturnValue"
-    + "(System.String)' is null."
+    + "ImplementsInterface::MethodWithNotNullReturnValue(System.S"
+    + "tring)' is null."
     IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_000f:  throw
     IL_0010:  ret
@@ -41,12 +40,12 @@
     // Code size       22 (0x16)
     .maxstack  2
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0001:  ldfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0015
     IL_0009:  pop
     IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
-    + "g ImplementsInheritedInterface::NotNullProperty()' is null."
+    + "g ImplementsInterface::NotNullProperty()' is null."
     IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
     IL_0014:  throw
     IL_0015:  ret
@@ -60,14 +59,13 @@
     IL_0001:  brtrue.s   IL_0013
     IL_0003:  ldstr      "value"
     IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
-    + "em.String ImplementsInheritedInterface::NotNullProperty()'"
-    + " to null."
+    + "em.String ImplementsInterface::NotNullProperty()' to null."
     IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
                                                                                      string)
     IL_0012:  throw
     IL_0013:  ldarg.0
     IL_0014:  ldarg.1
-    IL_0015:  stfld      string ImplementsInheritedInterface::'<NotNullProperty>k__BackingField'
+    IL_0015:  stfld      string ImplementsInterface::'<NotNullProperty>k__BackingField'
     IL_001a:  ret
   } 
   .method public hidebysig specialname rtspecialname 

--- a/TestsExplicit/ApprovedTests.Indexers.approved.txt
+++ b/TestsExplicit/ApprovedTests.Indexers.approved.txt
@@ -1,0 +1,184 @@
+﻿.class public auto ansi beforefieldinit Indexers
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit NonNullable
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname 
+            instance string  get_Item(string nonNullParam1,
+                                      string nonNullParam2) cil managed
+    {
+      .param [1]
+      .param [2]
+      // Code size       59 (0x3b)
+      .maxstack  2
+      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+      IL_0000:  ldarg.1
+      IL_0001:  brtrue.s   IL_0013
+      IL_0003:  ldstr      "nonNullParam1"
+      IL_0008:  ldstr      "[NullGuard] nonNullParam1 is null."
+      IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0012:  throw
+      IL_0013:  ldarg.2
+      IL_0014:  brtrue.s   IL_0026
+      IL_0016:  ldstr      "nonNullParam2"
+      IL_001b:  ldstr      "[NullGuard] nonNullParam2 is null."
+      IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0025:  throw
+      IL_0026:  ldstr      "return value of NonNullable"
+      IL_002b:  dup
+      IL_002c:  brtrue.s   IL_003a
+      IL_002e:  pop
+      IL_002f:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+      + "g Indexers/NonNullable::Item(System.String,System.String)' is null."
+      IL_0034:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_0039:  throw
+      IL_003a:  ret
+    } // end of method NonNullable::get_Item
+    .method public hidebysig specialname 
+            instance void  set_Item(string nonNullParam1,
+                                    string nonNullParam2,
+                                    string 'value') cil managed
+    {
+      .param [1]
+      .param [2]
+      // Code size       58 (0x3a)
+      .maxstack  2
+      IL_0000:  ldarg.3
+      IL_0001:  brtrue.s   IL_0013
+      IL_0003:  ldstr      "value"
+      IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+      + "em.String Indexers/NonNullable::Item(System.String,System.String)' to n"
+      + "ull."
+      IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0012:  throw
+      IL_0013:  ldarg.1
+      IL_0014:  brtrue.s   IL_0026
+      IL_0016:  ldstr      "nonNullParam1"
+      IL_001b:  ldstr      "[NullGuard] nonNullParam1 is null."
+      IL_0020:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0025:  throw
+      IL_0026:  ldarg.2
+      IL_0027:  brtrue.s   IL_0039
+      IL_0029:  ldstr      "nonNullParam2"
+      IL_002e:  ldstr      "[NullGuard] nonNullParam2 is null."
+      IL_0033:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0038:  throw
+      IL_0039:  ret
+    } // end of method NonNullable::set_Item
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method NonNullable::.ctor
+    .property instance string Item(string,
+                                   string)
+    {
+      .get instance string Indexers/NonNullable::get_Item(string,
+                                                          string)
+      .set instance void Indexers/NonNullable::set_Item(string,
+                                                        string,
+                                                        string)
+    } // end of property NonNullable::Item
+  } 
+  .class auto ansi nested public beforefieldinit PassThroughGetterReturnValue
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname 
+            instance string  get_Item(string returnValue) cil managed
+    {
+      .param [1]
+      // Code size       17 (0x11)
+      .maxstack  2
+      IL_0000:  ldarg.1
+      IL_0001:  dup
+      IL_0002:  brtrue.s   IL_0010
+      IL_0004:  pop
+      IL_0005:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+      + "g Indexers/PassThroughGetterReturnValue::Item(System.String)' is null."
+      IL_000a:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_000f:  throw
+      IL_0010:  ret
+    } // end of method PassThroughGetterReturnValue::get_Item
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method PassThroughGetterReturnValue::.ctor
+    .property instance string Item(string)
+    {
+      .get instance string Indexers/PassThroughGetterReturnValue::get_Item(string)
+    } // end of property PassThroughGetterReturnValue::Item
+  } 
+  .class auto ansi nested public beforefieldinit AllowedNulls
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname 
+            instance string  get_Item(string allowNull,
+                                      valuetype [mscorlib]System.Nullable`1<int32> nullableInt,
+                                      [opt] string optional) cil managed
+    {
+      .param [1]
+      .param [3] = nullref
+      // Code size       2 (0x2)
+      .maxstack  1
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method AllowedNulls::get_Item
+    .method public hidebysig specialname 
+            instance void  set_Item(string allowNull,
+                                    valuetype [mscorlib]System.Nullable`1<int32> nullableInt,
+                                    [opt] string optional,
+                                    string 'value') cil managed
+    {
+      .param [1]
+      .param [3] = nullref
+      // Code size       1 (0x1)
+      .maxstack  0
+      IL_0000:  ret
+    } // end of method AllowedNulls::set_Item
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method AllowedNulls::.ctor
+    .property instance string Item(string,
+                                   valuetype [mscorlib]System.Nullable`1<int32>,
+                                   string)
+    {
+      .set instance void Indexers/AllowedNulls::set_Item(string,
+                                                         valuetype [mscorlib]System.Nullable`1<int32>,
+                                                         string,
+                                                         string)
+      .get instance string Indexers/AllowedNulls::get_Item(string,
+                                                           valuetype [mscorlib]System.Nullable`1<int32>,
+                                                           string)
+    } // end of property AllowedNulls::Item
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/TestsExplicit/ApprovedTests.Indexers.approved.txt
+++ b/TestsExplicit/ApprovedTests.Indexers.approved.txt
@@ -12,7 +12,6 @@
       .param [2]
       // Code size       59 (0x3b)
       .maxstack  2
-      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
       IL_0000:  ldarg.1
       IL_0001:  brtrue.s   IL_0013
       IL_0003:  ldstr      "nonNullParam1"

--- a/TestsExplicit/ApprovedTests.InfosList.approved.txt
+++ b/TestsExplicit/ApprovedTests.InfosList.approved.txt
@@ -1,2 +1,2 @@
 ﻿Infos: [0] = 	Removing reference to 'NullGuard.dll'.
-Infos: [1] = Mode=Implicit, ValidationFlags=AllPublic
+Infos: [1] = Mode=Explicit, ValidationFlags=AllPublic

--- a/TestsExplicit/ApprovedTests.InterfaceBadAttributes.approved.txt
+++ b/TestsExplicit/ApprovedTests.InterfaceBadAttributes.approved.txt
@@ -1,0 +1,34 @@
+﻿.class interface private abstract auto ansi InterfaceBadAttributes
+{
+  .method public hidebysig newslot abstract virtual 
+          instance void  MethodWithNoNullCheckOnParam(string arg) cil managed
+  {
+    .param [1]
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance string  get_PropertyWithNoNullCheckOnSet() cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance void  set_PropertyWithNoNullCheckOnSet(string 'value') cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance string  get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
+  {
+  } 
+  .method public hidebysig newslot specialname abstract virtual 
+          instance void  set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
+  {
+  } 
+  .method public hidebysig newslot abstract virtual 
+          instance string  MethodAllowsNullReturnValue() cil managed
+  {
+  } 
+  .property instance string PropertyWithNoNullCheckOnSet()
+  {
+  } 
+  .property instance string PropertyAllowsNullGetButDoesNotAllowNullSet()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.PublicNestedInsideNonPublic.approved.txt
+++ b/TestsExplicit/ApprovedTests.PublicNestedInsideNonPublic.approved.txt
@@ -1,0 +1,34 @@
+﻿.class private auto ansi beforefieldinit NonPublicWithNested
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit PublicNestedClass
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig instance string 
+            MethodReturnsNull() cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method PublicNestedClass::MethodReturnsNull
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method PublicNestedClass::.ctor
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/TestsExplicit/ApprovedTests.SimpleClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.SimpleClass.approved.txt
@@ -11,7 +11,6 @@
   {
     // Code size       7 (0x7)
     .maxstack  1
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret

--- a/TestsExplicit/ApprovedTests.SimpleClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.SimpleClass.approved.txt
@@ -1,0 +1,714 @@
+﻿.class public auto ansi beforefieldinit SimpleClass
+       extends [mscorlib]System.Object
+{
+  .field private string '<NonNullProperty>k__BackingField'
+  .field private string '<NullProperty>k__BackingField'
+  .field private string '<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+  .field private string '<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+  .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       25 (0x19)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ldarg.1
+    IL_0007:  ldnull
+    IL_0008:  stind.ref
+    IL_0009:  ldarg.1
+    IL_000a:  ldind.ref
+    IL_000b:  brtrue.s   IL_0018
+    IL_000d:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
+    IL_0012:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0017:  throw
+    IL_0018:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(string nonNullArg,
+                               string nullArg) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       43 (0x2b)
+    .maxstack  3
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0019:  ldarg.1
+    IL_001a:  ldstr      " "
+    IL_001f:  ldarg.2
+    IL_0020:  call       string [mscorlib]System.String::Concat(string,
+                                                                string,
+                                                                string)
+    IL_0025:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_002a:  ret
+  } 
+  .method public hidebysig instance void 
+          SomeMethod(string nonNullArg,
+                     string nullArg) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       26 (0x1a)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0019:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_NonNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<NonNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::NonNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NonNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::NonNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string SimpleClass::'<NonNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_NullProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<NullProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NullProperty(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string SimpleClass::'<NullProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::PropertyAllowsNullGetButDoesNotAllowNullSet()' t"
+    + "o null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string SimpleClass::'<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyAllowsNullSetButDoesNotAllowNullGet() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::PropertyAllowsNullSetButDoesNotAllowNullGet()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyAllowsNullSetButDoesNotAllowNullGet(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string SimpleClass::'<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname instance valuetype [mscorlib]System.Nullable`1<int32> 
+          get_NonNullNullableProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      valuetype [mscorlib]System.Nullable`1<int32> SimpleClass::'<NonNullNullableProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NonNullNullableProperty(valuetype [mscorlib]System.Nullable`1<int32> 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      valuetype [mscorlib]System.Nullable`1<int32> SimpleClass::'<NonNullNullableProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodWithReturnValue(bool returnNull) cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0018
+    IL_0003:  ldstr      ""
+    IL_0008:  dup
+    IL_0009:  brtrue.s   IL_0017
+    IL_000b:  pop
+    IL_000c:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithReturnValue(System.Boolean)' is null."
+    IL_0011:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0016:  throw
+    IL_0017:  ret
+    IL_0018:  ldnull
+    IL_0019:  dup
+    IL_001a:  brtrue.s   IL_0028
+    IL_001c:  pop
+    IL_001d:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithReturnValue(System.Boolean)' is null."
+    IL_0022:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0027:  throw
+    IL_0028:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithRef(object& returnNull) cil managed
+  {
+    .param [1]
+    // Code size       21 (0x15)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldind.ref
+    IL_0002:  brtrue.s   IL_0014
+    IL_0004:  ldstr      "returnNull"
+    IL_0009:  ldstr      "[NullGuard] returnNull is null."
+    IL_000e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0013:  throw
+    IL_0014:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGeneric<T>(!!T returnNull) cil managed
+  {
+    .param [1]
+    // Code size       25 (0x19)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  box        !!T
+    IL_0006:  brtrue.s   IL_0018
+    IL_0008:  ldstr      "returnNull"
+    IL_000d:  ldstr      "[NullGuard] returnNull is null."
+    IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0017:  throw
+    IL_0018:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGenericRef<T>(!!T& returnNull) cil managed
+  {
+    .param [1]
+    // Code size       30 (0x1e)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldobj      !!T
+    IL_0006:  box        !!T
+    IL_000b:  brtrue.s   IL_001d
+    IL_000d:  ldstr      "returnNull"
+    IL_0012:  ldstr      "[NullGuard] returnNull is null."
+    IL_0017:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_001c:  throw
+    IL_001d:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodAllowsNullReturnValue() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  1
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodWithCanBeNullResult() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  1
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOutValue([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       19 (0x13)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.1
+    IL_0004:  ldind.ref
+    IL_0005:  brtrue.s   IL_0012
+    IL_0007:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
+    IL_000c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0011:  throw
+    IL_0012:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithAllowedNullOutValue([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       4 (0x4)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ret
+  } 
+  .method public hidebysig instance void 
+          PublicWrapperOfPrivateMethod() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldnull
+    IL_0002:  call       instance void SimpleClass::SomePrivateMethod(string)
+    IL_0007:  ret
+  } 
+  .method private hidebysig instance void 
+          SomePrivateMethod(string x) cil managed
+  {
+    .param [1]
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.1
+    IL_0001:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0006:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithTwoRefs(string& first,
+                            string& second) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       41 (0x29)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldind.ref
+    IL_0002:  brtrue.s   IL_0014
+    IL_0004:  ldstr      "first"
+    IL_0009:  ldstr      "[NullGuard] first is null."
+    IL_000e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0013:  throw
+    IL_0014:  ldarg.2
+    IL_0015:  ldind.ref
+    IL_0016:  brtrue.s   IL_0028
+    IL_0018:  ldstr      "second"
+    IL_001d:  ldstr      "[NullGuard] second is null."
+    IL_0022:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0027:  throw
+    IL_0028:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithTwoOuts([out] string& first,
+                            [out] string& second) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       37 (0x25)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.2
+    IL_0004:  ldnull
+    IL_0005:  stind.ref
+    IL_0006:  ldarg.1
+    IL_0007:  ldind.ref
+    IL_0008:  brtrue.s   IL_0015
+    IL_000a:  ldstr      "[NullGuard] Out parameter 'first' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ldarg.2
+    IL_0016:  ldind.ref
+    IL_0017:  brtrue.s   IL_0024
+    IL_0019:  ldstr      "[NullGuard] Out parameter 'second' is null."
+    IL_001e:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0023:  throw
+    IL_0024:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameter([opt] string optional) cil managed
+  {
+    .param [1] = nullref
+    // Code size       1 (0x1)
+    .maxstack  0
+    IL_0000:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameterWithNonNullDefaultValue([opt] string optional) cil managed
+  {
+    .param [1] = "default"
+    // Code size       20 (0x14)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "optional"
+    IL_0008:  ldstr      "[NullGuard] optional is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute([opt] string optional) cil managed
+  {
+    .param [1] = "default"
+    // Code size       1 (0x1)
+    .maxstack  0
+    IL_0000:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGenericOut<T>([out] !!T& item) cil managed
+  {
+    .param [1]
+    // Code size       32 (0x20)
+    .maxstack  1
+    IL_0000:  ldarg.1
+    IL_0001:  initobj    !!T
+    IL_0007:  ldarg.1
+    IL_0008:  ldobj      !!T
+    IL_000d:  box        !!T
+    IL_0012:  brtrue.s   IL_001f
+    IL_0014:  ldstr      "[NullGuard] Out parameter 'item' is null."
+    IL_0019:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_001e:  throw
+    IL_001f:  ret
+  } 
+  .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
+  {
+    // Code size       59 (0x3b)
+    .maxstack  2
+    .locals init ([0] !!T __var_0)
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_001d
+    IL_0003:  call       !!0 [mscorlib]System.Activator::CreateInstance<!!0>()
+    IL_0008:  dup
+    IL_0009:  box        !!T
+    IL_000e:  brtrue.s   IL_001c
+    IL_0010:  pop
+    IL_0011:  ldstr      "[NullGuard] Return value of method 'T SimpleClass:"
+    + ":MethodWithGenericReturn(System.Boolean)' is null."
+    IL_0016:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_001b:  throw
+    IL_001c:  ret
+    IL_001d:  ldloca.s   __var_0
+    IL_001f:  initobj    !!T
+    IL_0025:  ldloc.0
+    IL_0026:  dup
+    IL_0027:  box        !!T
+    IL_002c:  brtrue.s   IL_003a
+    IL_002e:  pop
+    IL_002f:  ldstr      "[NullGuard] Return value of method 'T SimpleClass:"
+    + ":MethodWithGenericReturn(System.Boolean)' is null."
+    IL_0034:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0039:  throw
+    IL_003a:  ret
+  } 
+  .method public hidebysig instance object 
+          MethodWithOutAndReturn([out] string& prefix) cil managed
+  {
+    .param [1]
+    // Code size       35 (0x23)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldnull
+    IL_0004:  ldarg.1
+    IL_0005:  ldind.ref
+    IL_0006:  brtrue.s   IL_0013
+    IL_0008:  ldstr      "[NullGuard] Out parameter 'prefix' is null."
+    IL_000d:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0012:  throw
+    IL_0013:  dup
+    IL_0014:  brtrue.s   IL_0022
+    IL_0016:  pop
+    IL_0017:  ldstr      "[NullGuard] Return value of method 'System.Object "
+    + "SimpleClass::MethodWithOutAndReturn(System.String&)' is null."
+    IL_001c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0021:  throw
+    IL_0022:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentGuard(string x) cil managed
+  {
+    .param [1]
+    // Code size       50 (0x32)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "x"
+    IL_0008:  ldstr      "[NullGuard] x is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0019:  brfalse.s  IL_002b
+    IL_001b:  ldstr      "x is null or empty."
+    IL_0020:  ldstr      "x"
+    IL_0025:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string,
+                                                                                 string)
+    IL_002a:  throw
+    IL_002b:  ldarg.1
+    IL_002c:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0031:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentNullGuard(string x) cil managed
+  {
+    .param [1]
+    // Code size       26 (0x1a)
+    .maxstack  1
+    IL_0000:  ldarg.1
+    IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0006:  brfalse.s  IL_0013
+    IL_0008:  ldstr      "x"
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0019:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentNullGuardWithMessage(string x) cil managed
+  {
+    .param [1]
+    // Code size       31 (0x1f)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0006:  brfalse.s  IL_0018
+    IL_0008:  ldstr      "x"
+    IL_000d:  ldstr      "x is null or empty."
+    IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0017:  throw
+    IL_0018:  ldarg.1
+    IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_001e:  ret
+  } 
+  .method public hidebysig instance string 
+          ReturnValueChecksWithBranchToRetInstruction() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init ([0] string returnValue)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldstr      ""
+    IL_0007:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000c:  ldc.i4.s   42
+    IL_000e:  bne.un.s   IL_001b
+    IL_0010:  ldstr      "Not reachable"
+    IL_0015:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001a:  throw
+    IL_001b:  ldloc.0
+    IL_001c:  dup
+    IL_001d:  brtrue.s   IL_002b
+    IL_001f:  pop
+    IL_0020:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::ReturnValueChecksWithBranchToRetInstruction()' is null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig instance void 
+          OutValueChecksWithBranchToRetInstruction([out] string& outParam) cil managed
+  {
+    .param [1]
+    // Code size       44 (0x2c)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldstr      ""
+    IL_0008:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000d:  ldc.i4.s   42
+    IL_000f:  bne.un.s   IL_001c
+    IL_0011:  ldstr      "Not reachable"
+    IL_0016:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001b:  throw
+    IL_001c:  ldarg.1
+    IL_001d:  ldind.ref
+    IL_001e:  brtrue.s   IL_002b
+    IL_0020:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_GetterReturnValueChecksWithBranchToRetInstruction() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init ([0] string returnValue)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldstr      ""
+    IL_0007:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000c:  ldc.i4.s   42
+    IL_000e:  bne.un.s   IL_001b
+    IL_0010:  ldstr      "Not reachable"
+    IL_0015:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001a:  throw
+    IL_001b:  ldloc.0
+    IL_001c:  dup
+    IL_001d:  brtrue.s   IL_002b
+    IL_001f:  pop
+    IL_0020:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::GetterReturnValueChecksWithBranchToRetInstruction()' is "
+    + "null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig instance void 
+          OutValueChecksWithRetInstructionAsSwitchCase(int32 i,
+                                                       [out] string& outParam) cil managed
+  {
+    .param [2]
+    // Code size       125 (0x7d)
+    .maxstack  2
+    IL_0000:  ldarg.2
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.1
+    IL_0004:  switch     ( 
+                          IL_0029,
+                          IL_0039,
+                          IL_0053,
+                          IL_0063)
+    IL_0019:  ldarg.2
+    IL_001a:  ldind.ref
+    IL_001b:  brtrue.s   IL_0028
+    IL_001d:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0022:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0027:  throw
+    IL_0028:  ret
+    IL_0029:  ldarg.2
+    IL_002a:  ldind.ref
+    IL_002b:  brtrue.s   IL_0038
+    IL_002d:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0032:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0037:  throw
+    IL_0038:  ret
+    IL_0039:  ldstr      "1"
+    IL_003e:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0043:  ldarg.2
+    IL_0044:  ldind.ref
+    IL_0045:  brtrue.s   IL_0052
+    IL_0047:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_004c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0051:  throw
+    IL_0052:  ret
+    IL_0053:  ldarg.2
+    IL_0054:  ldind.ref
+    IL_0055:  brtrue.s   IL_0062
+    IL_0057:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_005c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0061:  throw
+    IL_0062:  ret
+    IL_0063:  ldstr      "3"
+    IL_0068:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_006d:  ldarg.2
+    IL_006e:  ldind.ref
+    IL_006f:  brtrue.s   IL_007c
+    IL_0071:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0076:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_007b:  throw
+    IL_007c:  ret
+  } 
+  .property instance string NonNullProperty()
+  {
+  } 
+  .property instance string NullProperty()
+  {
+  } 
+  .property instance string PropertyAllowsNullGetButDoesNotAllowNullSet()
+  {
+  } 
+  .property instance string PropertyAllowsNullSetButDoesNotAllowNullGet()
+  {
+  } 
+  .property instance valuetype [mscorlib]System.Nullable`1<int32>
+          NonNullNullableProperty()
+  {
+  } 
+  .property instance string GetterReturnValueChecksWithBranchToRetInstruction()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/TestsExplicit/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -11,7 +11,6 @@
   {
     // Code size       7 (0x7)
     .maxstack  1
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret

--- a/TestsExplicit/ApprovedTests.SimpleClassNoAssert.approved.txt
+++ b/TestsExplicit/ApprovedTests.SimpleClassNoAssert.approved.txt
@@ -1,0 +1,714 @@
+﻿.class public auto ansi beforefieldinit SimpleClass
+       extends [mscorlib]System.Object
+{
+  .field private string '<NonNullProperty>k__BackingField'
+  .field private string '<NullProperty>k__BackingField'
+  .field private string '<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+  .field private string '<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+  .field private valuetype [mscorlib]System.Nullable`1<int32> '<NonNullNullableProperty>k__BackingField'
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       25 (0x19)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ldarg.1
+    IL_0007:  ldnull
+    IL_0008:  stind.ref
+    IL_0009:  ldarg.1
+    IL_000a:  ldind.ref
+    IL_000b:  brtrue.s   IL_0018
+    IL_000d:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
+    IL_0012:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0017:  throw
+    IL_0018:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(string nonNullArg,
+                               string nullArg) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       43 (0x2b)
+    .maxstack  3
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0019:  ldarg.1
+    IL_001a:  ldstr      " "
+    IL_001f:  ldarg.2
+    IL_0020:  call       string [mscorlib]System.String::Concat(string,
+                                                                string,
+                                                                string)
+    IL_0025:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_002a:  ret
+  } 
+  .method public hidebysig instance void 
+          SomeMethod(string nonNullArg,
+                     string nullArg) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       26 (0x1a)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0019:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_NonNullProperty() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<NonNullProperty>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::NonNullProperty()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NonNullProperty(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::NonNullProperty()' to null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string SimpleClass::'<NonNullProperty>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_NullProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<NullProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NullProperty(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string SimpleClass::'<NullProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyAllowsNullGetButDoesNotAllowNullSet() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyAllowsNullGetButDoesNotAllowNullSet(string 'value') cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "value"
+    IL_0008:  ldstr      "[NullGuard] Cannot set the value of property 'Syst"
+    + "em.String SimpleClass::PropertyAllowsNullGetButDoesNotAllowNullSet()' t"
+    + "o null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.0
+    IL_0014:  ldarg.1
+    IL_0015:  stfld      string SimpleClass::'<PropertyAllowsNullGetButDoesNotAllowNullSet>k__BackingField'
+    IL_001a:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_PropertyAllowsNullSetButDoesNotAllowNullGet() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      string SimpleClass::'<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+    IL_0006:  dup
+    IL_0007:  brtrue.s   IL_0015
+    IL_0009:  pop
+    IL_000a:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::PropertyAllowsNullSetButDoesNotAllowNullGet()' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_PropertyAllowsNullSetButDoesNotAllowNullGet(string 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      string SimpleClass::'<PropertyAllowsNullSetButDoesNotAllowNullGet>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname instance valuetype [mscorlib]System.Nullable`1<int32> 
+          get_NonNullNullableProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      valuetype [mscorlib]System.Nullable`1<int32> SimpleClass::'<NonNullNullableProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NonNullNullableProperty(valuetype [mscorlib]System.Nullable`1<int32> 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      valuetype [mscorlib]System.Nullable`1<int32> SimpleClass::'<NonNullNullableProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodWithReturnValue(bool returnNull) cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0018
+    IL_0003:  ldstr      ""
+    IL_0008:  dup
+    IL_0009:  brtrue.s   IL_0017
+    IL_000b:  pop
+    IL_000c:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithReturnValue(System.Boolean)' is null."
+    IL_0011:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0016:  throw
+    IL_0017:  ret
+    IL_0018:  ldnull
+    IL_0019:  dup
+    IL_001a:  brtrue.s   IL_0028
+    IL_001c:  pop
+    IL_001d:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::MethodWithReturnValue(System.Boolean)' is null."
+    IL_0022:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0027:  throw
+    IL_0028:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithRef(object& returnNull) cil managed
+  {
+    .param [1]
+    // Code size       21 (0x15)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldind.ref
+    IL_0002:  brtrue.s   IL_0014
+    IL_0004:  ldstr      "returnNull"
+    IL_0009:  ldstr      "[NullGuard] returnNull is null."
+    IL_000e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0013:  throw
+    IL_0014:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGeneric<T>(!!T returnNull) cil managed
+  {
+    .param [1]
+    // Code size       25 (0x19)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  box        !!T
+    IL_0006:  brtrue.s   IL_0018
+    IL_0008:  ldstr      "returnNull"
+    IL_000d:  ldstr      "[NullGuard] returnNull is null."
+    IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0017:  throw
+    IL_0018:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGenericRef<T>(!!T& returnNull) cil managed
+  {
+    .param [1]
+    // Code size       30 (0x1e)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldobj      !!T
+    IL_0006:  box        !!T
+    IL_000b:  brtrue.s   IL_001d
+    IL_000d:  ldstr      "returnNull"
+    IL_0012:  ldstr      "[NullGuard] returnNull is null."
+    IL_0017:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_001c:  throw
+    IL_001d:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodAllowsNullReturnValue() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  1
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } 
+  .method public hidebysig instance string 
+          MethodWithCanBeNullResult() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  1
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOutValue([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       19 (0x13)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.1
+    IL_0004:  ldind.ref
+    IL_0005:  brtrue.s   IL_0012
+    IL_0007:  ldstr      "[NullGuard] Out parameter 'nonNullOutArg' is null."
+    IL_000c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0011:  throw
+    IL_0012:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithAllowedNullOutValue([out] string& nonNullOutArg) cil managed
+  {
+    .param [1]
+    // Code size       4 (0x4)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ret
+  } 
+  .method public hidebysig instance void 
+          PublicWrapperOfPrivateMethod() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  2
+    IL_0000:  ldarg.0
+    IL_0001:  ldnull
+    IL_0002:  call       instance void SimpleClass::SomePrivateMethod(string)
+    IL_0007:  ret
+  } 
+  .method private hidebysig instance void 
+          SomePrivateMethod(string x) cil managed
+  {
+    .param [1]
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.1
+    IL_0001:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0006:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithTwoRefs(string& first,
+                            string& second) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       41 (0x29)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldind.ref
+    IL_0002:  brtrue.s   IL_0014
+    IL_0004:  ldstr      "first"
+    IL_0009:  ldstr      "[NullGuard] first is null."
+    IL_000e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0013:  throw
+    IL_0014:  ldarg.2
+    IL_0015:  ldind.ref
+    IL_0016:  brtrue.s   IL_0028
+    IL_0018:  ldstr      "second"
+    IL_001d:  ldstr      "[NullGuard] second is null."
+    IL_0022:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0027:  throw
+    IL_0028:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithTwoOuts([out] string& first,
+                            [out] string& second) cil managed
+  {
+    .param [1]
+    .param [2]
+    // Code size       37 (0x25)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.2
+    IL_0004:  ldnull
+    IL_0005:  stind.ref
+    IL_0006:  ldarg.1
+    IL_0007:  ldind.ref
+    IL_0008:  brtrue.s   IL_0015
+    IL_000a:  ldstr      "[NullGuard] Out parameter 'first' is null."
+    IL_000f:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0014:  throw
+    IL_0015:  ldarg.2
+    IL_0016:  ldind.ref
+    IL_0017:  brtrue.s   IL_0024
+    IL_0019:  ldstr      "[NullGuard] Out parameter 'second' is null."
+    IL_001e:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0023:  throw
+    IL_0024:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameter([opt] string optional) cil managed
+  {
+    .param [1] = nullref
+    // Code size       1 (0x1)
+    .maxstack  0
+    IL_0000:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameterWithNonNullDefaultValue([opt] string optional) cil managed
+  {
+    .param [1] = "default"
+    // Code size       20 (0x14)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "optional"
+    IL_0008:  ldstr      "[NullGuard] optional is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute([opt] string optional) cil managed
+  {
+    .param [1] = "default"
+    // Code size       1 (0x1)
+    .maxstack  0
+    IL_0000:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithGenericOut<T>([out] !!T& item) cil managed
+  {
+    .param [1]
+    // Code size       32 (0x20)
+    .maxstack  1
+    IL_0000:  ldarg.1
+    IL_0001:  initobj    !!T
+    IL_0007:  ldarg.1
+    IL_0008:  ldobj      !!T
+    IL_000d:  box        !!T
+    IL_0012:  brtrue.s   IL_001f
+    IL_0014:  ldstr      "[NullGuard] Out parameter 'item' is null."
+    IL_0019:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_001e:  throw
+    IL_001f:  ret
+  } 
+  .method public hidebysig instance !!T  MethodWithGenericReturn<T>(bool returnNull) cil managed
+  {
+    // Code size       59 (0x3b)
+    .maxstack  2
+    .locals init ([0] !!T __var_0)
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_001d
+    IL_0003:  call       !!0 [mscorlib]System.Activator::CreateInstance<!!0>()
+    IL_0008:  dup
+    IL_0009:  box        !!T
+    IL_000e:  brtrue.s   IL_001c
+    IL_0010:  pop
+    IL_0011:  ldstr      "[NullGuard] Return value of method 'T SimpleClass:"
+    + ":MethodWithGenericReturn(System.Boolean)' is null."
+    IL_0016:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_001b:  throw
+    IL_001c:  ret
+    IL_001d:  ldloca.s   __var_0
+    IL_001f:  initobj    !!T
+    IL_0025:  ldloc.0
+    IL_0026:  dup
+    IL_0027:  box        !!T
+    IL_002c:  brtrue.s   IL_003a
+    IL_002e:  pop
+    IL_002f:  ldstr      "[NullGuard] Return value of method 'T SimpleClass:"
+    + ":MethodWithGenericReturn(System.Boolean)' is null."
+    IL_0034:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0039:  throw
+    IL_003a:  ret
+  } 
+  .method public hidebysig instance object 
+          MethodWithOutAndReturn([out] string& prefix) cil managed
+  {
+    .param [1]
+    // Code size       35 (0x23)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldnull
+    IL_0004:  ldarg.1
+    IL_0005:  ldind.ref
+    IL_0006:  brtrue.s   IL_0013
+    IL_0008:  ldstr      "[NullGuard] Out parameter 'prefix' is null."
+    IL_000d:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0012:  throw
+    IL_0013:  dup
+    IL_0014:  brtrue.s   IL_0022
+    IL_0016:  pop
+    IL_0017:  ldstr      "[NullGuard] Return value of method 'System.Object "
+    + "SimpleClass::MethodWithOutAndReturn(System.String&)' is null."
+    IL_001c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0021:  throw
+    IL_0022:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentGuard(string x) cil managed
+  {
+    .param [1]
+    // Code size       50 (0x32)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "x"
+    IL_0008:  ldstr      "[NullGuard] x is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0019:  brfalse.s  IL_002b
+    IL_001b:  ldstr      "x is null or empty."
+    IL_0020:  ldstr      "x"
+    IL_0025:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string,
+                                                                                 string)
+    IL_002a:  throw
+    IL_002b:  ldarg.1
+    IL_002c:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0031:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentNullGuard(string x) cil managed
+  {
+    .param [1]
+    // Code size       26 (0x1a)
+    .maxstack  1
+    IL_0000:  ldarg.1
+    IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0006:  brfalse.s  IL_0013
+    IL_0008:  ldstr      "x"
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
+    IL_0012:  throw
+    IL_0013:  ldarg.1
+    IL_0014:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0019:  ret
+  } 
+  .method public hidebysig instance void 
+          MethodWithExistingArgumentNullGuardWithMessage(string x) cil managed
+  {
+    .param [1]
+    // Code size       31 (0x1f)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  call       bool [mscorlib]System.String::IsNullOrEmpty(string)
+    IL_0006:  brfalse.s  IL_0018
+    IL_0008:  ldstr      "x"
+    IL_000d:  ldstr      "x is null or empty."
+    IL_0012:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0017:  throw
+    IL_0018:  ldarg.1
+    IL_0019:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_001e:  ret
+  } 
+  .method public hidebysig instance string 
+          ReturnValueChecksWithBranchToRetInstruction() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init ([0] string returnValue)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldstr      ""
+    IL_0007:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000c:  ldc.i4.s   42
+    IL_000e:  bne.un.s   IL_001b
+    IL_0010:  ldstr      "Not reachable"
+    IL_0015:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001a:  throw
+    IL_001b:  ldloc.0
+    IL_001c:  dup
+    IL_001d:  brtrue.s   IL_002b
+    IL_001f:  pop
+    IL_0020:  ldstr      "[NullGuard] Return value of method 'System.String "
+    + "SimpleClass::ReturnValueChecksWithBranchToRetInstruction()' is null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig instance void 
+          OutValueChecksWithBranchToRetInstruction([out] string& outParam) cil managed
+  {
+    .param [1]
+    // Code size       44 (0x2c)
+    .maxstack  2
+    IL_0000:  ldarg.1
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldstr      ""
+    IL_0008:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000d:  ldc.i4.s   42
+    IL_000f:  bne.un.s   IL_001c
+    IL_0011:  ldstr      "Not reachable"
+    IL_0016:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001b:  throw
+    IL_001c:  ldarg.1
+    IL_001d:  ldind.ref
+    IL_001e:  brtrue.s   IL_002b
+    IL_0020:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig specialname instance string 
+          get_GetterReturnValueChecksWithBranchToRetInstruction() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init ([0] string returnValue)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldstr      ""
+    IL_0007:  call       instance int32 [mscorlib]System.String::get_Length()
+    IL_000c:  ldc.i4.s   42
+    IL_000e:  bne.un.s   IL_001b
+    IL_0010:  ldstr      "Not reachable"
+    IL_0015:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
+    IL_001a:  throw
+    IL_001b:  ldloc.0
+    IL_001c:  dup
+    IL_001d:  brtrue.s   IL_002b
+    IL_001f:  pop
+    IL_0020:  ldstr      "[NullGuard] Return value of property 'System.Strin"
+    + "g SimpleClass::GetterReturnValueChecksWithBranchToRetInstruction()' is "
+    + "null."
+    IL_0025:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_002a:  throw
+    IL_002b:  ret
+  } 
+  .method public hidebysig instance void 
+          OutValueChecksWithRetInstructionAsSwitchCase(int32 i,
+                                                       [out] string& outParam) cil managed
+  {
+    .param [2]
+    // Code size       125 (0x7d)
+    .maxstack  2
+    IL_0000:  ldarg.2
+    IL_0001:  ldnull
+    IL_0002:  stind.ref
+    IL_0003:  ldarg.1
+    IL_0004:  switch     ( 
+                          IL_0029,
+                          IL_0039,
+                          IL_0053,
+                          IL_0063)
+    IL_0019:  ldarg.2
+    IL_001a:  ldind.ref
+    IL_001b:  brtrue.s   IL_0028
+    IL_001d:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0022:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0027:  throw
+    IL_0028:  ret
+    IL_0029:  ldarg.2
+    IL_002a:  ldind.ref
+    IL_002b:  brtrue.s   IL_0038
+    IL_002d:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0032:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0037:  throw
+    IL_0038:  ret
+    IL_0039:  ldstr      "1"
+    IL_003e:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0043:  ldarg.2
+    IL_0044:  ldind.ref
+    IL_0045:  brtrue.s   IL_0052
+    IL_0047:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_004c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0051:  throw
+    IL_0052:  ret
+    IL_0053:  ldarg.2
+    IL_0054:  ldind.ref
+    IL_0055:  brtrue.s   IL_0062
+    IL_0057:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_005c:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_0061:  throw
+    IL_0062:  ret
+    IL_0063:  ldstr      "3"
+    IL_0068:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_006d:  ldarg.2
+    IL_006e:  ldind.ref
+    IL_006f:  brtrue.s   IL_007c
+    IL_0071:  ldstr      "[NullGuard] Out parameter 'outParam' is null."
+    IL_0076:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+    IL_007b:  throw
+    IL_007c:  ret
+  } 
+  .property instance string NonNullProperty()
+  {
+  } 
+  .property instance string NullProperty()
+  {
+  } 
+  .property instance string PropertyAllowsNullGetButDoesNotAllowNullSet()
+  {
+  } 
+  .property instance string PropertyAllowsNullSetButDoesNotAllowNullGet()
+  {
+  } 
+  .property instance valuetype [mscorlib]System.Nullable`1<int32>
+          NonNullNullableProperty()
+  {
+  } 
+  .property instance string GetterReturnValueChecksWithBranchToRetInstruction()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.SkipIXamlMetadataProvider.approved.txt
+++ b/TestsExplicit/ApprovedTests.SkipIXamlMetadataProvider.approved.txt
@@ -1,0 +1,14 @@
+﻿.class public auto ansi beforefieldinit XamlMetadataProvider
+       extends [mscorlib]System.Object
+       implements Windows.UI.Xaml.Markup.IXamlMetadataProvider
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/TestsExplicit/ApprovedTests.SpecialClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.SpecialClass.approved.txt
@@ -1,0 +1,750 @@
+﻿.class public auto ansi beforefieldinit SpecialClass
+       extends [mscorlib]System.Object
+{
+  .class auto ansi sealed nested private beforefieldinit '<CountTo>d__0'
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,
+                    [mscorlib]System.Collections.IEnumerable,
+                    class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
+                    [mscorlib]System.IDisposable,
+                    [mscorlib]System.Collections.IEnumerator
+  {
+    .field private int32 '<>1__state'
+    .field private int32 '<>2__current'
+    .field private int32 '<>l__initialThreadId'
+    .field private int32 '<i>5__1'
+    .field private int32 end
+    .field public int32 '<>3__end'
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 '<>1__state') cil managed
+    {
+      // Code size       25 (0x19)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_000d:  ldarg.0
+      IL_000e:  call       int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
+      IL_0013:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>l__initialThreadId'
+      IL_0018:  ret
+    } // end of method '<CountTo>d__0'::.ctor
+    .method private hidebysig newslot virtual final 
+            instance void  System.IDisposable.Dispose() cil managed
+    {
+      .override [mscorlib]System.IDisposable::Dispose
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method '<CountTo>d__0'::System.IDisposable.Dispose
+    .method private hidebysig newslot virtual final 
+            instance bool  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Collections.IEnumerator::MoveNext
+      // Code size       92 (0x5c)
+      .maxstack  3
+      .locals init ([0] int32 V_0,
+               [1] int32 V_1)
+      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  brfalse.s  IL_0010
+      IL_000a:  ldloc.0
+      IL_000b:  ldc.i4.1
+      IL_000c:  beq.s      IL_0035
+      IL_000e:  ldc.i4.0
+      IL_000f:  ret
+      IL_0010:  ldarg.0
+      IL_0011:  ldc.i4.m1
+      IL_0012:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_0017:  ldarg.0
+      IL_0018:  ldc.i4.0
+      IL_0019:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<i>5__1'
+      IL_001e:  br.s       IL_004c
+      IL_0020:  ldarg.0
+      IL_0021:  ldarg.0
+      IL_0022:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<i>5__1'
+      IL_0027:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>2__current'
+      IL_002c:  ldarg.0
+      IL_002d:  ldc.i4.1
+      IL_002e:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_0033:  ldc.i4.1
+      IL_0034:  ret
+      IL_0035:  ldarg.0
+      IL_0036:  ldc.i4.m1
+      IL_0037:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_003c:  ldarg.0
+      IL_003d:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<i>5__1'
+      IL_0042:  stloc.1
+      IL_0043:  ldarg.0
+      IL_0044:  ldloc.1
+      IL_0045:  ldc.i4.1
+      IL_0046:  add
+      IL_0047:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<i>5__1'
+      IL_004c:  ldarg.0
+      IL_004d:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<i>5__1'
+      IL_0052:  ldarg.0
+      IL_0053:  ldfld      int32 SpecialClass/'<CountTo>d__0'::end
+      IL_0058:  blt.s      IL_0020
+      IL_005a:  ldc.i4.0
+      IL_005b:  ret
+    } // end of method '<CountTo>d__0'::MoveNext
+    .method private hidebysig newslot specialname virtual final 
+            instance int32  'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'() cil managed
+    {
+      .override  method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>2__current'
+      IL_0006:  ret
+    } // end of method '<CountTo>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'
+    .method private hidebysig newslot virtual final 
+            instance void  System.Collections.IEnumerator.Reset() cil managed
+    {
+      .override [mscorlib]System.Collections.IEnumerator::Reset
+      // Code size       6 (0x6)
+      .maxstack  8
+      IL_0000:  newobj     instance void [mscorlib]System.NotSupportedException::.ctor()
+      IL_0005:  throw
+    } // end of method '<CountTo>d__0'::System.Collections.IEnumerator.Reset
+    .method private hidebysig newslot specialname virtual final 
+            instance object  System.Collections.IEnumerator.get_Current() cil managed
+    {
+      .override [mscorlib]System.Collections.IEnumerator::get_Current
+      // Code size       12 (0xc)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>2__current'
+      IL_0006:  box        [mscorlib]System.Int32
+      IL_000b:  ret
+    } // end of method '<CountTo>d__0'::System.Collections.IEnumerator.get_Current
+    .method private hidebysig newslot virtual final 
+            instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> 
+            'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'() cil managed
+    {
+      .override  method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      // Code size       55 (0x37)
+      .maxstack  2
+      .locals init (class SpecialClass/'<CountTo>d__0' V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_0006:  ldc.i4.s   -2
+      IL_0008:  bne.un.s   IL_0022
+      IL_000a:  ldarg.0
+      IL_000b:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>l__initialThreadId'
+      IL_0010:  call       int32 [mscorlib]System.Environment::get_CurrentManagedThreadId()
+      IL_0015:  bne.un.s   IL_0022
+      IL_0017:  ldarg.0
+      IL_0018:  ldc.i4.0
+      IL_0019:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
+      IL_001e:  ldarg.0
+      IL_001f:  stloc.0
+      IL_0020:  br.s       IL_0029
+      IL_0022:  ldc.i4.0
+      IL_0023:  newobj     instance void SpecialClass/'<CountTo>d__0'::.ctor(int32)
+      IL_0028:  stloc.0
+      IL_0029:  ldloc.0
+      IL_002a:  ldarg.0
+      IL_002b:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>3__end'
+      IL_0030:  stfld      int32 SpecialClass/'<CountTo>d__0'::end
+      IL_0035:  ldloc.0
+      IL_0036:  ret
+    } // end of method '<CountTo>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'
+    .method private hidebysig newslot virtual final 
+            instance class [mscorlib]System.Collections.IEnumerator 
+            System.Collections.IEnumerable.GetEnumerator() cil managed
+    {
+      .override [mscorlib]System.Collections.IEnumerable::GetEnumerator
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SpecialClass/'<CountTo>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
+      IL_0006:  ret
+    } // end of method '<CountTo>d__0'::System.Collections.IEnumerable.GetEnumerator
+    .property instance int32 'System.Collections.Generic.IEnumerator<System.Int32>.Current'()
+    {
+      .get instance int32 SpecialClass/'<CountTo>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.get_Current'()
+    } // end of property '<CountTo>d__0'::'System.Collections.Generic.IEnumerator<System.Int32>.Current'
+    .property instance object System.Collections.IEnumerator.Current()
+    {
+      .get instance object SpecialClass/'<CountTo>d__0'::System.Collections.IEnumerator.get_Current()
+    } // end of property '<CountTo>d__0'::System.Collections.IEnumerator.Current
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass1_0'
+         extends [mscorlib]System.Object
+  {
+    .field public string nonNullArg
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method '<>c__DisplayClass1_0'::.ctor
+    .method assembly hidebysig instance void 
+            '<SomeMethodAsync>b__0'() cil managed
+    {
+      // Code size       12 (0xc)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      string SpecialClass/'<>c__DisplayClass1_0'::nonNullArg
+      IL_0006:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000b:  ret
+    } // end of method '<>c__DisplayClass1_0'::'<SomeMethodAsync>b__0'
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<SomeMethodAsync>d__1'
+         extends [mscorlib]System.ValueType
+         implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+  {
+    .field public int32 '<>1__state'
+    .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+    .field public string nonNullArg
+    .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter '<>u__1'
+    .method private hidebysig newslot virtual final 
+            instance void  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+      // Code size       172 (0xac)
+      .maxstack  3
+      .locals init ([0] int32 V_0,
+               [1] class SpecialClass/'<>c__DisplayClass1_0' 'CS$<>8__locals0',
+               [2] valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter V_2,
+               [3] class [mscorlib]System.Exception V_3)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+      IL_0006:  stloc.0
+      .try
+      {
+        IL_0007:  ldloc.0
+        IL_0008:  brfalse.s  IL_005c
+        IL_000a:  newobj     instance void SpecialClass/'<>c__DisplayClass1_0'::.ctor()
+        IL_000f:  stloc.1
+        IL_0010:  ldloc.1
+        IL_0011:  ldarg.0
+        IL_0012:  ldfld      string SpecialClass/'<SomeMethodAsync>d__1'::nonNullArg
+        IL_0017:  stfld      string SpecialClass/'<>c__DisplayClass1_0'::nonNullArg
+        IL_001c:  ldloc.1
+        IL_001d:  ldftn      instance void SpecialClass/'<>c__DisplayClass1_0'::'<SomeMethodAsync>b__0'()
+        IL_0023:  newobj     instance void [mscorlib]System.Action::.ctor(object,
+                                                                          native int)
+        IL_0028:  call       class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Threading.Tasks.Task::Run(class [mscorlib]System.Action)
+        IL_002d:  callvirt   instance valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter [mscorlib]System.Threading.Tasks.Task::GetAwaiter()
+        IL_0032:  stloc.2
+        IL_0033:  ldloca.s   V_2
+        IL_0035:  call       instance bool [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::get_IsCompleted()
+        IL_003a:  brtrue.s   IL_0078
+        IL_003c:  ldarg.0
+        IL_003d:  ldc.i4.0
+        IL_003e:  dup
+        IL_003f:  stloc.0
+        IL_0040:  stfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+        IL_0045:  ldarg.0
+        IL_0046:  ldloc.2
+        IL_0047:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<SomeMethodAsync>d__1'::'<>u__1'
+        IL_004c:  ldarg.0
+        IL_004d:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+        IL_0052:  ldloca.s   V_2
+        IL_0054:  ldarg.0
+        IL_0055:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter,valuetype SpecialClass/'<SomeMethodAsync>d__1'>(!!0&,
+                                                                                                                                                                                                                                                    !!1&)
+        IL_005a:  leave.s    IL_00ab
+        IL_005c:  ldarg.0
+        IL_005d:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<SomeMethodAsync>d__1'::'<>u__1'
+        IL_0062:  stloc.2
+        IL_0063:  ldarg.0
+        IL_0064:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<SomeMethodAsync>d__1'::'<>u__1'
+        IL_0069:  initobj    [mscorlib]System.Runtime.CompilerServices.TaskAwaiter
+        IL_006f:  ldarg.0
+        IL_0070:  ldc.i4.m1
+        IL_0071:  dup
+        IL_0072:  stloc.0
+        IL_0073:  stfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+        IL_0078:  ldloca.s   V_2
+        IL_007a:  call       instance void [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::GetResult()
+        IL_007f:  leave.s    IL_0098
+      }  // end .try
+      catch [mscorlib]System.Exception 
+      {
+        IL_0081:  stloc.3
+        IL_0082:  ldarg.0
+        IL_0083:  ldc.i4.s   -2
+        IL_0085:  stfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+        IL_008a:  ldarg.0
+        IL_008b:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+        IL_0090:  ldloc.3
+        IL_0091:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [mscorlib]System.Exception)
+        IL_0096:  leave.s    IL_00ab
+      }  // end handler
+      IL_0098:  ldarg.0
+      IL_0099:  ldc.i4.s   -2
+      IL_009b:  stfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+      IL_00a0:  ldarg.0
+      IL_00a1:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+      IL_00a6:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+      IL_00ab:  ret
+    } // end of method '<SomeMethodAsync>d__1'::MoveNext
+    .method private hidebysig newslot virtual final 
+            instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+      IL_0006:  ldarg.1
+      IL_0007:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+      IL_000c:  ret
+    } // end of method '<SomeMethodAsync>d__1'::SetStateMachine
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<>c__DisplayClass2_0'
+         extends [mscorlib]System.Object
+  {
+    .field public bool returnNull
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method '<>c__DisplayClass2_0'::.ctor
+    .method assembly hidebysig instance string 
+            '<MethodWithReturnValueAsync>b__0'() cil managed
+    {
+      // Code size       16 (0x10)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      bool SpecialClass/'<>c__DisplayClass2_0'::returnNull
+      IL_0006:  brtrue.s   IL_000e
+      IL_0008:  ldstr      ""
+      IL_000d:  ret
+      IL_000e:  ldnull
+      IL_000f:  ret
+    } // end of method '<>c__DisplayClass2_0'::'<MethodWithReturnValueAsync>b__0'
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<MethodWithReturnValueAsync>d__2'
+         extends [mscorlib]System.ValueType
+         implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+  {
+    .field public int32 '<>1__state'
+    .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
+    .field public bool returnNull
+    .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string> '<>u__1'
+    .method private hidebysig newslot virtual final 
+            instance void  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+      // Code size       201 (0xc9)
+      .maxstack  3
+      .locals init ([0] int32 V_0,
+               [1] string V_1,
+               [2] class SpecialClass/'<>c__DisplayClass2_0' 'CS$<>8__locals0',
+               [3] string V_3,
+               [4] valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string> V_4,
+               [5] class [mscorlib]System.Exception V_5)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+      IL_0006:  stloc.0
+      .try
+      {
+        IL_0007:  ldloc.0
+        IL_0008:  brfalse.s  IL_005e
+        IL_000a:  newobj     instance void SpecialClass/'<>c__DisplayClass2_0'::.ctor()
+        IL_000f:  stloc.2
+        IL_0010:  ldloc.2
+        IL_0011:  ldarg.0
+        IL_0012:  ldfld      bool SpecialClass/'<MethodWithReturnValueAsync>d__2'::returnNull
+        IL_0017:  stfld      bool SpecialClass/'<>c__DisplayClass2_0'::returnNull
+        IL_001c:  ldloc.2
+        IL_001d:  ldftn      instance string SpecialClass/'<>c__DisplayClass2_0'::'<MethodWithReturnValueAsync>b__0'()
+        IL_0023:  newobj     instance void class [mscorlib]System.Func`1<string>::.ctor(object,
+                                                                                        native int)
+        IL_0028:  call       class [mscorlib]System.Threading.Tasks.Task`1<!!0> [mscorlib]System.Threading.Tasks.Task::Run<string>(class [mscorlib]System.Func`1<!!0>)
+        IL_002d:  callvirt   instance valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<!0> class [mscorlib]System.Threading.Tasks.Task`1<string>::GetAwaiter()
+        IL_0032:  stloc.s    V_4
+        IL_0034:  ldloca.s   V_4
+        IL_0036:  call       instance bool valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string>::get_IsCompleted()
+        IL_003b:  brtrue.s   IL_007b
+        IL_003d:  ldarg.0
+        IL_003e:  ldc.i4.0
+        IL_003f:  dup
+        IL_0040:  stloc.0
+        IL_0041:  stfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+        IL_0046:  ldarg.0
+        IL_0047:  ldloc.s    V_4
+        IL_0049:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>u__1'
+        IL_004e:  ldarg.0
+        IL_004f:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+        IL_0054:  ldloca.s   V_4
+        IL_0056:  ldarg.0
+        IL_0057:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string>,valuetype SpecialClass/'<MethodWithReturnValueAsync>d__2'>(!!0&,
+                                                                                                                                                                                                                                                                                             !!1&)
+        IL_005c:  leave.s    IL_00c8
+        IL_005e:  ldarg.0
+        IL_005f:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>u__1'
+        IL_0064:  stloc.s    V_4
+        IL_0066:  ldarg.0
+        IL_0067:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>u__1'
+        IL_006c:  initobj    valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string>
+        IL_0072:  ldarg.0
+        IL_0073:  ldc.i4.m1
+        IL_0074:  dup
+        IL_0075:  stloc.0
+        IL_0076:  stfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+        IL_007b:  ldloca.s   V_4
+        IL_007d:  call       instance !0 valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<string>::GetResult()
+        IL_0082:  stloc.3
+        IL_0083:  ldloc.3
+        IL_0084:  stloc.1
+        IL_0085:  leave.s    IL_00a0
+      }  // end .try
+      catch [mscorlib]System.Exception 
+      {
+        IL_0087:  stloc.s    V_5
+        IL_0089:  ldarg.0
+        IL_008a:  ldc.i4.s   -2
+        IL_008c:  stfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+        IL_0091:  ldarg.0
+        IL_0092:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+        IL_0097:  ldloc.s    V_5
+        IL_0099:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetException(class [mscorlib]System.Exception)
+        IL_009e:  leave.s    IL_00c8
+      }  // end handler
+      IL_00a0:  ldarg.0
+      IL_00a1:  ldc.i4.s   -2
+      IL_00a3:  stfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+      IL_00ae:  ldloc.1
+      IL_00af:  dup
+      IL_00b0:  brtrue.s   IL_00c3
+      IL_00b2:  pop
+      IL_00b3:  ldstr      "[NullGuard] Return value of method 'System.Threadi"
+      + "ng.Tasks.Task`1<System.String> SpecialClass::MethodWithReturnValueAsync"
+      + "(System.Boolean)' is null."
+      IL_00b8:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_00bd:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetException(class [mscorlib]System.Exception)
+      IL_00c2:  ret
+      IL_00c3:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetResult(!0)
+      IL_00c8:  ret
+    } // end of method '<MethodWithReturnValueAsync>d__2'::MoveNext
+    .method private hidebysig newslot virtual final 
+            instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+      IL_0006:  ldarg.1
+      IL_0007:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+      IL_000c:  ret
+    } // end of method '<MethodWithReturnValueAsync>d__2'::SetStateMachine
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<MethodAllowsNullReturnValueAsync>d__3'
+         extends [mscorlib]System.ValueType
+         implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+  {
+    .field public int32 '<>1__state'
+    .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> '<>t__builder'
+    .field private valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter '<>u__1'
+    .method private hidebysig newslot virtual final 
+            instance void  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+      // Code size       147 (0x93)
+      .maxstack  3
+      .locals init ([0] int32 V_0,
+               [1] string V_1,
+               [2] valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter V_2,
+               [3] class [mscorlib]System.Exception V_3)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+      IL_0006:  stloc.0
+      .try
+      {
+        IL_0007:  ldloc.0
+        IL_0008:  brfalse.s  IL_0040
+        IL_000a:  ldc.i4.s   100
+        IL_000c:  call       class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Threading.Tasks.Task::Delay(int32)
+        IL_0011:  callvirt   instance valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter [mscorlib]System.Threading.Tasks.Task::GetAwaiter()
+        IL_0016:  stloc.2
+        IL_0017:  ldloca.s   V_2
+        IL_0019:  call       instance bool [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::get_IsCompleted()
+        IL_001e:  brtrue.s   IL_005c
+        IL_0020:  ldarg.0
+        IL_0021:  ldc.i4.0
+        IL_0022:  dup
+        IL_0023:  stloc.0
+        IL_0024:  stfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+        IL_0029:  ldarg.0
+        IL_002a:  ldloc.2
+        IL_002b:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>u__1'
+        IL_0030:  ldarg.0
+        IL_0031:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+        IL_0036:  ldloca.s   V_2
+        IL_0038:  ldarg.0
+        IL_0039:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter,valuetype SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'>(!!0&,
+                                                                                                                                                                                                                                                                                         !!1&)
+        IL_003e:  leave.s    IL_0092
+        IL_0040:  ldarg.0
+        IL_0041:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>u__1'
+        IL_0046:  stloc.2
+        IL_0047:  ldarg.0
+        IL_0048:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>u__1'
+        IL_004d:  initobj    [mscorlib]System.Runtime.CompilerServices.TaskAwaiter
+        IL_0053:  ldarg.0
+        IL_0054:  ldc.i4.m1
+        IL_0055:  dup
+        IL_0056:  stloc.0
+        IL_0057:  stfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+        IL_005c:  ldloca.s   V_2
+        IL_005e:  call       instance void [mscorlib]System.Runtime.CompilerServices.TaskAwaiter::GetResult()
+        IL_0063:  ldnull
+        IL_0064:  stloc.1
+        IL_0065:  leave.s    IL_007e
+      }  // end .try
+      catch [mscorlib]System.Exception 
+      {
+        IL_0067:  stloc.3
+        IL_0068:  ldarg.0
+        IL_0069:  ldc.i4.s   -2
+        IL_006b:  stfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+        IL_0070:  ldarg.0
+        IL_0071:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+        IL_0076:  ldloc.3
+        IL_0077:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetException(class [mscorlib]System.Exception)
+        IL_007c:  leave.s    IL_0092
+      }  // end handler
+      IL_007e:  ldarg.0
+      IL_007f:  ldc.i4.s   -2
+      IL_0081:  stfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+      IL_0086:  ldarg.0
+      IL_0087:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+      IL_008c:  ldloc.1
+      IL_008d:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetResult(!0)
+      IL_0092:  ret
+    } // end of method '<MethodAllowsNullReturnValueAsync>d__3'::MoveNext
+    .method private hidebysig newslot virtual final 
+            instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+      IL_0006:  ldarg.1
+      IL_0007:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+      IL_000c:  ret
+    } // end of method '<MethodAllowsNullReturnValueAsync>d__3'::SetStateMachine
+  } 
+  .class auto ansi sealed nested private beforefieldinit '<NoAwaitCode>d__4'
+         extends [mscorlib]System.ValueType
+         implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+  {
+    .field public int32 '<>1__state'
+    .field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+    .method private hidebysig newslot virtual final 
+            instance void  MoveNext() cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+      // Code size       56 (0x38)
+      .maxstack  2
+      .locals init ([0] int32 V_0,
+               [1] int32 V_1,
+               [2] class [mscorlib]System.Exception V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 SpecialClass/'<NoAwaitCode>d__4'::'<>1__state'
+      IL_0006:  stloc.0
+      .try
+      {
+        IL_0007:  ldc.i4.s   42
+        IL_0009:  stloc.1
+        IL_000a:  leave.s    IL_0023
+      }  // end .try
+      catch [mscorlib]System.Exception 
+      {
+        IL_000c:  stloc.2
+        IL_000d:  ldarg.0
+        IL_000e:  ldc.i4.s   -2
+        IL_0010:  stfld      int32 SpecialClass/'<NoAwaitCode>d__4'::'<>1__state'
+        IL_0015:  ldarg.0
+        IL_0016:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+        IL_001b:  ldloc.2
+        IL_001c:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [mscorlib]System.Exception)
+        IL_0021:  leave.s    IL_0037
+      }  // end handler
+      IL_0023:  ldarg.0
+      IL_0024:  ldc.i4.s   -2
+      IL_0026:  stfld      int32 SpecialClass/'<NoAwaitCode>d__4'::'<>1__state'
+      IL_002b:  ldarg.0
+      IL_002c:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+      IL_0031:  ldloc.1
+      IL_0032:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+      IL_0037:  ret
+    } // end of method '<NoAwaitCode>d__4'::MoveNext
+    .method private hidebysig newslot virtual final 
+            instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+    {
+      .override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+      IL_0006:  ldarg.1
+      IL_0007:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+      IL_000c:  ret
+    } // end of method '<NoAwaitCode>d__4'::SetStateMachine
+  } 
+  .method public hidebysig instance class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> 
+          CountTo(int32 end) cil managed
+  {
+                                                                                                                                          3C 43 6F 75 6E 74 54 6F 3E 64 5F 5F 30 00 00 )    // <CountTo>d__0..
+    // Code size       15 (0xf)
+    .maxstack  3
+    IL_0000:  ldc.i4.s   -2
+    IL_0002:  newobj     instance void SpecialClass/'<CountTo>d__0'::.ctor(int32)
+    IL_0007:  dup
+    IL_0008:  ldarg.1
+    IL_0009:  stfld      int32 SpecialClass/'<CountTo>d__0'::'<>3__end'
+    IL_000e:  ret
+  } 
+  .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task 
+          SomeMethodAsync(string nonNullArg,
+                          string nullArg) cil managed
+  {
+                                                                                                                                       3C 53 6F 6D 65 4D 65 74 68 6F 64 41 73 79 6E 63   // <SomeMethodAsync
+                                                                                                                                       3E 64 5F 5F 31 00 00 )                            // >d__1..
+    .param [1]
+    .param [2]
+    // Code size       76 (0x4c)
+    .maxstack  2
+    .locals init ([0] valuetype SpecialClass/'<SomeMethodAsync>d__1' V_0,
+             [1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "nonNullArg"
+    IL_0008:  ldstr      "[NullGuard] nonNullArg is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+    IL_0013:  ldloca.s   V_0
+    IL_0015:  ldarg.1
+    IL_0016:  stfld      string SpecialClass/'<SomeMethodAsync>d__1'::nonNullArg
+    IL_001b:  ldloca.s   V_0
+    IL_001d:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+    IL_0022:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+    IL_0027:  ldloca.s   V_0
+    IL_0029:  ldc.i4.m1
+    IL_002a:  stfld      int32 SpecialClass/'<SomeMethodAsync>d__1'::'<>1__state'
+    IL_002f:  ldloc.0
+    IL_0030:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+    IL_0035:  stloc.1
+    IL_0036:  ldloca.s   V_1
+    IL_0038:  ldloca.s   V_0
+    IL_003a:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype SpecialClass/'<SomeMethodAsync>d__1'>(!!0&)
+    IL_003f:  ldloca.s   V_0
+    IL_0041:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder SpecialClass/'<SomeMethodAsync>d__1'::'<>t__builder'
+    IL_0046:  call       instance class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+    IL_004b:  ret
+  } 
+  .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
+          MethodWithReturnValueAsync(bool returnNull) cil managed
+  {
+                                                                                                                                       3C 4D 65 74 68 6F 64 57 69 74 68 52 65 74 75 72   // <MethodWithRetur
+                                                                                                                                       6E 56 61 6C 75 65 41 73 79 6E 63 3E 64 5F 5F 32   // nValueAsync>d__2
+                                                                                                                                       00 00 ) 
+    // Code size       57 (0x39)
+    .maxstack  2
+    .locals init ([0] valuetype SpecialClass/'<MethodWithReturnValueAsync>d__2' V_0,
+             [1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  ldarg.1
+    IL_0003:  stfld      bool SpecialClass/'<MethodWithReturnValueAsync>d__2'::returnNull
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Create()
+    IL_000f:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+    IL_0014:  ldloca.s   V_0
+    IL_0016:  ldc.i4.m1
+    IL_0017:  stfld      int32 SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>1__state'
+    IL_001c:  ldloc.0
+    IL_001d:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+    IL_0022:  stloc.1
+    IL_0023:  ldloca.s   V_1
+    IL_0025:  ldloca.s   V_0
+    IL_0027:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Start<valuetype SpecialClass/'<MethodWithReturnValueAsync>d__2'>(!!0&)
+    IL_002c:  ldloca.s   V_0
+    IL_002e:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodWithReturnValueAsync>d__2'::'<>t__builder'
+    IL_0033:  call       instance class [mscorlib]System.Threading.Tasks.Task`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::get_Task()
+    IL_0038:  ret
+  } 
+  .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<string> 
+          MethodAllowsNullReturnValueAsync() cil managed
+  {
+                                                                                                                                       3C 4D 65 74 68 6F 64 41 6C 6C 6F 77 73 4E 75 6C   // <MethodAllowsNul
+                                                                                                                                       6C 52 65 74 75 72 6E 56 61 6C 75 65 41 73 79 6E   // lReturnValueAsyn
+                                                                                                                                       63 3E 64 5F 5F 33 00 00 )                         // c>d__3..
+    // Code size       49 (0x31)
+    .maxstack  2
+    .locals init ([0] valuetype SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3' V_0,
+             [1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Create()
+    IL_0007:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+    IL_000c:  ldloca.s   V_0
+    IL_000e:  ldc.i4.m1
+    IL_000f:  stfld      int32 SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>1__state'
+    IL_0014:  ldloc.0
+    IL_0015:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+    IL_001a:  stloc.1
+    IL_001b:  ldloca.s   V_1
+    IL_001d:  ldloca.s   V_0
+    IL_001f:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::Start<valuetype SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'>(!!0&)
+    IL_0024:  ldloca.s   V_0
+    IL_0026:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string> SpecialClass/'<MethodAllowsNullReturnValueAsync>d__3'::'<>t__builder'
+    IL_002b:  call       instance class [mscorlib]System.Threading.Tasks.Task`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<string>::get_Task()
+    IL_0030:  ret
+  } 
+  .method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task`1<int32> 
+          NoAwaitCode() cil managed
+  {
+                                                                                                                                       3C 4E 6F 41 77 61 69 74 43 6F 64 65 3E 64 5F 5F   // <NoAwaitCode>d__
+                                                                                                                                       34 00 00 )                                        // 4..
+    // Code size       49 (0x31)
+    .maxstack  2
+    .locals init ([0] valuetype SpecialClass/'<NoAwaitCode>d__4' V_0,
+             [1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+    IL_0007:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+    IL_000c:  ldloca.s   V_0
+    IL_000e:  ldc.i4.m1
+    IL_000f:  stfld      int32 SpecialClass/'<NoAwaitCode>d__4'::'<>1__state'
+    IL_0014:  ldloc.0
+    IL_0015:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+    IL_001a:  stloc.1
+    IL_001b:  ldloca.s   V_1
+    IL_001d:  ldloca.s   V_0
+    IL_001f:  call       instance void valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype SpecialClass/'<NoAwaitCode>d__4'>(!!0&)
+    IL_0024:  ldloca.s   V_0
+    IL_0026:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> SpecialClass/'<NoAwaitCode>d__4'::'<>t__builder'
+    IL_002b:  call       instance class [mscorlib]System.Threading.Tasks.Task`1<!0> valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+    IL_0030:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/TestsExplicit/ApprovedTests.SpecialClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.SpecialClass.approved.txt
@@ -46,7 +46,6 @@
       .maxstack  3
       .locals init ([0] int32 V_0,
                [1] int32 V_1)
-      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 SpecialClass/'<CountTo>d__0'::'<>1__state'
       IL_0006:  stloc.0

--- a/TestsExplicit/ApprovedTests.UnsafeClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.UnsafeClass.approved.txt
@@ -8,7 +8,6 @@
     .param [1]
     // Code size       3 (0x3)
     .maxstack  1
-    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
     IL_0000:  ldc.i4.0
     IL_0001:  conv.u
     IL_0002:  ret

--- a/TestsExplicit/ApprovedTests.UnsafeClass.approved.txt
+++ b/TestsExplicit/ApprovedTests.UnsafeClass.approved.txt
@@ -1,0 +1,47 @@
+﻿.class public auto ansi beforefieldinit UnsafeClass
+       extends [mscorlib]System.Object
+{
+  .field private int32* '<NullProperty>k__BackingField'
+  .method public hidebysig instance int32* 
+          MethodWithAmp(int32* 'instance') cil managed
+  {
+    .param [1]
+    // Code size       3 (0x3)
+    .maxstack  1
+    .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    IL_0000:  ldc.i4.0
+    IL_0001:  conv.u
+    IL_0002:  ret
+  } 
+  .method public hidebysig specialname instance int32* 
+          get_NullProperty() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      int32* UnsafeClass::'<NullProperty>k__BackingField'
+    IL_0006:  ret
+  } 
+  .method public hidebysig specialname instance void 
+          set_NullProperty(int32* 'value') cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      int32* UnsafeClass::'<NullProperty>k__BackingField'
+    IL_0007:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+  .property instance int32* NullProperty()
+  {
+  } 
+}

--- a/TestsExplicit/ApprovedTests.WarnsList.approved.txt
+++ b/TestsExplicit/ApprovedTests.WarnsList.approved.txt
@@ -1,0 +1,1 @@
+﻿Warns:  is empty

--- a/TestsExplicit/ApprovedTests.cs
+++ b/TestsExplicit/ApprovedTests.cs
@@ -1,5 +1,6 @@
 ﻿#if(DEBUG)
 
+using System;
 using System.Linq;
 using ApprovalTests;
 using NUnit.Framework;
@@ -82,25 +83,73 @@ public class ApprovedTests
     [Test]
     public void DerivedClass()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "DerivedClass"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "InternalBase.DerivedClass"), v => v.Replace("InternalBase.", string.Empty));
     }
 
     [Test]
     public void ImplementsInterface()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInterface"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "InternalBase.ImplementsInterface"), v => v.Replace("InternalBase.", string.Empty));
     }
 
     [Test]
     public void ImplementsInheritedInterface()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInheritedInterface"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "InternalBase.ImplementsInheritedInterface"), v => v.Replace("InternalBase.", string.Empty));
     }
 
     [Test]
     public void ImplementsInterfaceExplicit()
     {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInterfaceExplicit"));
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "InternalBase.ImplementsInterfaceExplicit"), v => v.Replace("InternalBase.", string.Empty));
+    }
+
+    [Test]
+    public void DerivedClassAssemblyBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "AssemblyBase.DerivedClass"), v => v.Replace("AssemblyBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInterfaceAssemblyBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "AssemblyBase.ImplementsInterface"), v => v.Replace("AssemblyBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInheritedInterfaceAssemblyBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "AssemblyBase.ImplementsInheritedInterface"), v => v.Replace("AssemblyBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInterfaceExplicitAssemblyBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "AssemblyBase.ImplementsInterfaceExplicit"), v => v.Replace("AssemblyBase.", string.Empty));
+    }
+
+    [Test]
+    public void DerivedClassExternalBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ExternalBase.DerivedClass"), v => v.Replace("ExternalBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInterfaceExternalBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ExternalBase.ImplementsInterface"), v => v.Replace("ExternalBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInheritedInterfaceExternalBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ExternalBase.ImplementsInheritedInterface"), v => v.Replace("ExternalBase.", string.Empty));
+    }
+
+    [Test]
+    public void ImplementsInterfaceExplicitExternalBase()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ExternalBase.ImplementsInterfaceExplicit"), v => v.Replace("ExternalBase.", string.Empty));
     }
 
     [Test]

--- a/TestsExplicit/ApprovedTests.cs
+++ b/TestsExplicit/ApprovedTests.cs
@@ -1,0 +1,125 @@
+﻿#if(DEBUG)
+
+using System.Linq;
+using ApprovalTests;
+using NUnit.Framework;
+
+[TestFixture]
+public class ApprovedTests
+{
+    [Test]
+    public void ClassWithBadAttributes()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithBadAttributes"));
+    }
+
+    [Test]
+    public void ClassWithPrivateMethod()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithPrivateMethod"));
+    }
+
+    [Test]
+    public void ClassWithPrivateMethodNoAssert()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithPrivateMethod"));
+    }
+
+    [Test]
+    public void GenericClass()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "GenericClass`1"));
+    }
+
+    [Test]
+    public void Indexers()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "Indexers"));
+    }
+
+    [Test]
+    public void InterfaceBadAttributes()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "InterfaceBadAttributes"));
+    }
+
+    [Test]
+    public void SimpleClass()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "SimpleClass"));
+    }
+
+    [Test]
+    public void SimpleClassNoAssert()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "SimpleClass"));
+    }
+
+    [Test]
+    public void SkipIXamlMetadataProvider()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "XamlMetadataProvider"));
+    }
+
+    [Test]
+    public void SpecialClass()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "SpecialClass"));
+    }
+
+    [Test]
+    public void PublicNestedInsideNonPublic()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "NonPublicWithNested"));
+    }
+
+    [Test]
+    public void UnsafeClass()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "UnsafeClass"));
+    }
+
+    [Test]
+    public void DerivedClass()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "DerivedClass"));
+    }
+
+    [Test]
+    public void ImplementsInterface()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInterface"));
+    }
+
+    [Test]
+    public void ImplementsInheritedInterface()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInheritedInterface"));
+    }
+
+    [Test]
+    public void ImplementsInterfaceExplicit()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ImplementsInterfaceExplicit"));
+    }
+
+    [Test]
+    public void InfosList()
+    {
+        Approvals.VerifyAll(AssemblyWeaver.Infos.OrderBy(e => e), "Infos: ");
+    }
+
+    [Test]
+    public void WarnsList()
+    {
+        Approvals.VerifyAll(AssemblyWeaver.Warns.OrderBy(e => e), "Warns: ");
+    }
+
+    [Test]
+    public void ErrorsList()
+    {
+        Approvals.VerifyAll(AssemblyWeaver.Errors.OrderBy(e => e), "Errors: ");
+    }
+}
+
+#endif

--- a/TestsExplicit/ExplicitSpecificTests.cs
+++ b/TestsExplicit/ExplicitSpecificTests.cs
@@ -1,0 +1,101 @@
+﻿namespace TestsExplicit
+{
+    using System;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    [TestFixtureSource(nameof(FixtureArgs))]
+    public class ExplicitSpecificTests
+    {
+        static object[] FixtureArgs = {
+            new object[] { "DerivedClass", string.Empty },
+            new object[] { "ImplementsInterface", string.Empty },
+            new object[] { "ImplementsInheritedInterface", string.Empty },
+            new object[] { "ImplementsInterfaceExplicit", "InterfaceWithAttributes." },
+        };
+
+        private readonly string _className;
+        private readonly string _interfaceName;
+
+        public ExplicitSpecificTests(string className, string interfaceName)
+        {
+            _className = className;
+            _interfaceName = interfaceName;
+        }
+
+        [Test]
+        public void InheritsNullabilityForMethodParameterAndThrowsOnNull()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            var exception = Assert.Throws<ArgumentNullException>(() => sample.MethodWithNotNullParameter((string)null, (string)null));
+            Assert.AreEqual("[NullGuard] arg is null.\r\nParameter name: arg", exception.Message);
+        }
+
+        [Test]
+        public void InheritsNullabilityForMethodParameterAndDoesNotThrowOnNotNull()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            Assert.DoesNotThrow(() => sample.MethodWithNotNullParameter((string)null, "Test"));
+        }
+
+        [Test]
+        public void InheritsNullabilityForMethodReturnAndThrowsOnNull()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithNotNullReturnValue((string)null));
+            Assert.AreEqual($"[NullGuard] Return value of method 'System.String {_className}::{_interfaceName}MethodWithNotNullReturnValue(System.String)' is null.", exception.Message);
+        }
+
+        [Test]
+        public void InheritsNullabilityForMethodReturnAndDoesNotThrowOnNotNull()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            Assert.DoesNotThrow(() => sample.MethodWithNotNullReturnValue("Test"));
+        }
+
+        [Test]
+        public void InheritsNullabilityForPropertyAndThrowsOnNullSet()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            var exception = Assert.Throws<ArgumentNullException>(() => sample.NotNullProperty = (string)null);
+            Assert.AreEqual($"[NullGuard] Cannot set the value of property 'System.String {_className}::{_interfaceName}NotNullProperty()' to null.\r\nParameter name: value", exception.Message);
+        }
+
+        [Test]
+        public void InheritsNullabilityForPropertyAndDoesNotThrowOnNotNullSet()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            Assert.DoesNotThrow(() => sample.NotNullProperty = "Test");
+        }
+
+        [Test]
+        public void InheritsNullabilityForPropertyAndThrowsOnNullGet()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            string value;
+            var exception = Assert.Throws<InvalidOperationException>(() => value = sample.NotNullProperty);
+            Assert.AreEqual($"[NullGuard] Return value of property 'System.String {_className}::{_interfaceName}NotNullProperty()' is null.", exception.Message);
+        }
+
+        [Test]
+        public void InheritsNullabilityForPropertyAndDoesNotThrowOnNotNullGet()
+        {
+            var type = AssemblyWeaver.Assembly.GetType(_className);
+            var sample = (dynamic)Activator.CreateInstance(type);
+            string value;
+            Assert.DoesNotThrow(() =>
+            {
+                sample.NotNullProperty = "Test";
+                value = sample.NotNullProperty;
+            });
+        }
+    }
+}

--- a/TestsExplicit/ExplicitSpecificTests.cs
+++ b/TestsExplicit/ExplicitSpecificTests.cs
@@ -9,10 +9,18 @@
     public class ExplicitSpecificTests
     {
         static object[] FixtureArgs = {
-            new object[] { "DerivedClass", string.Empty },
-            new object[] { "ImplementsInterface", string.Empty },
-            new object[] { "ImplementsInheritedInterface", string.Empty },
-            new object[] { "ImplementsInterfaceExplicit", "InterfaceWithAttributes." },
+            new object[] { "InternalBase.DerivedClass", string.Empty },
+            new object[] { "InternalBase.ImplementsInterface", string.Empty },
+            new object[] { "InternalBase.ImplementsInheritedInterface", string.Empty },
+            new object[] { "InternalBase.ImplementsInterfaceExplicit", "InterfaceWithAttributes." },
+            new object[] { "AssemblyBase.DerivedClass", string.Empty },
+            new object[] { "AssemblyBase.ImplementsInterface", string.Empty },
+            new object[] { "AssemblyBase.ImplementsInheritedInterface", string.Empty },
+            new object[] { "AssemblyBase.ImplementsInterfaceExplicit", "AssemblyWithAnnotations.InterfaceWithAttributes." },
+            new object[] { "ExternalBase.DerivedClass", string.Empty },
+            new object[] { "ExternalBase.ImplementsInterface", string.Empty },
+            new object[] { "ExternalBase.ImplementsInheritedInterface", string.Empty },
+            new object[] { "ExternalBase.ImplementsInterfaceExplicit", "AssemblyWithExternalAnnotations.InterfaceWithAttributes." },
         };
 
         private readonly string _className;

--- a/TestsExplicit/Helpers/AssemblyWeaver.cs
+++ b/TestsExplicit/Helpers/AssemblyWeaver.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Xml.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Pdb;
+using NUnit.Framework;
+
+public static class AssemblyWeaver
+{
+    public static Assembly Assembly;
+    public static string BeforeAssemblyPath;
+    public static string BeforeSymbolPath;
+    public static string AfterAssemblyPath;
+    public static string AfterSymbolPath;
+
+    public static dynamic GetInstance(string typeName)
+    {
+        var type = Assembly.GetType(typeName);
+        return Activator.CreateInstance(type);
+    }
+
+    static AssemblyWeaver()
+    {
+        var testDirectory = TestContext.CurrentContext.TestDirectory;
+        BeforeAssemblyPath = Path.GetFullPath(Path.Combine(testDirectory, @"..\..\..\..\AssemblyToProcessExplicit\bin\Debug\net452\AssemblyToProcessExplicit.dll"));
+        BeforeSymbolPath = Path.ChangeExtension(BeforeAssemblyPath, "pdb");
+#if (!DEBUG)
+        BeforeAssemblyPath = BeforeAssemblyPath.Replace("Debug", "Release");
+        BeforeSymbolPath = BeforeSymbolPath.Replace("Debug", "Release");
+#endif
+
+        AfterAssemblyPath = BeforeAssemblyPath.Replace(".dll", "2.dll");
+        AfterSymbolPath = BeforeSymbolPath.Replace(".pdb", "2.pdb");
+
+        if (File.Exists(AfterAssemblyPath))
+        {
+            File.Delete(AfterAssemblyPath);
+        }
+        if (File.Exists(AfterSymbolPath))
+        {
+            File.Delete(AfterSymbolPath);
+        }
+
+        var assemblyResolver = new MockAssemblyResolver();
+        var readerParameters = new ReaderParameters {AssemblyResolver = assemblyResolver};
+        var writerParameters = new WriterParameters();
+
+        if (File.Exists(BeforeSymbolPath))
+        {
+            readerParameters.ReadSymbols = true;
+            readerParameters.SymbolReaderProvider = new PdbReaderProvider();
+            readerParameters.SymbolStream = new FileStream(BeforeSymbolPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            writerParameters.WriteSymbols = true;
+            writerParameters.SymbolWriterProvider = new PdbWriterProvider();
+        }
+
+        var moduleDefinition = ModuleDefinition.ReadModule(BeforeAssemblyPath, readerParameters);
+
+
+        var weavingTask = new ModuleWeaver
+        {
+            Config = new XElement("NullGuard",
+                new XAttribute("IncludeDebugAssert", false),
+                new XAttribute("ExcludeRegex", "^ClassToExclude$")),
+            ModuleDefinition = moduleDefinition,
+            AssemblyResolver = assemblyResolver,
+            LogInfo = LogInfo,
+            LogWarn = LogWarn,
+            LogError = LogError,
+            DefineConstants = new List<string> {"DEBUG"} // Always testing the debug weaver
+        };
+
+        weavingTask.Execute();
+
+        var assemblyNameDefinition = moduleDefinition.Assembly?.Name;
+        assemblyNameDefinition.Version = new Version(1, 1, DateTime.Now.Year, (int)((DateTime.Now.DayOfYear * 24 * 60 * 60L) + DateTime.Now.TimeOfDay.TotalSeconds));
+
+        moduleDefinition.Write(AfterAssemblyPath, writerParameters);
+
+        Assembly = Assembly.LoadFile(AfterAssemblyPath);
+    }
+
+    static void LogInfo(string error)
+    {
+        Infos.Add(error);
+    }
+
+    static void LogWarn(string error)
+    {
+        Warns.Add(error);
+    }
+
+    static void LogError(string error)
+    {
+        Errors.Add(error);
+    }
+
+    public static List<string> Infos = new List<string>();
+    public static List<string> Warns = new List<string>();
+    public static List<string> Errors = new List<string>();
+}

--- a/TestsExplicit/Helpers/Decompiler.cs
+++ b/TestsExplicit/Helpers/Decompiler.cs
@@ -22,8 +22,6 @@ public static class Decompiler
         };
         using (var process = Process.Start(startInfo))
         {
-            // process.WaitForExit(10000);
-
             var stringBuilder = new StringBuilder();
             string line;
             while ((line = process.StandardOutput.ReadLine()) != null)
@@ -37,6 +35,10 @@ public static class Decompiler
                     continue;
                 }
                 if (line.StartsWith("// "))
+                {
+                    continue;
+                }
+                if (line.StartsWith("//0"))
                 {
                     continue;
                 }

--- a/TestsExplicit/Helpers/Decompiler.cs
+++ b/TestsExplicit/Helpers/Decompiler.cs
@@ -64,6 +64,10 @@ public static class Decompiler
                 {
                     continue;
                 }
+                if (line.Contains(".language '"))
+                {
+                    continue;
+                }
 
                 stringBuilder.AppendLine(line);
             }

--- a/TestsExplicit/Helpers/MockAssemblyResolver.cs
+++ b/TestsExplicit/Helpers/MockAssemblyResolver.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+
+public class MockAssemblyResolver : IAssemblyResolver
+{
+    public AssemblyDefinition Resolve(AssemblyNameReference name)
+    {
+        return Resolve(name.Name);
+    }
+
+    public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public AssemblyDefinition Resolve(string fullName)
+    {
+        var firstOrDefault = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.GetName().Name == fullName);
+        if (firstOrDefault != null)
+        {
+            return AssemblyDefinition.ReadAssembly(firstOrDefault.CodeBase.Replace("file:///", ""));
+        }
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.Load(fullName);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        var codeBase = assembly.CodeBase.Replace("file:///", "");
+        return AssemblyDefinition.ReadAssembly(codeBase);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/TestsExplicit/Helpers/SdkToolsHelper.cs
+++ b/TestsExplicit/Helpers/SdkToolsHelper.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+
+public static class SdkToolsHelper
+{
+    private static readonly string[] PeVerifyProbingPaths =
+    {
+        @"C:\Program Files\Microsoft SDKs\Windows\v10.0A\bin\netfx 4.6.1 Tools",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\netfx 4.6.1 Tools",
+        @"C:\Program Files\Microsoft SDKs\Windows\v8.1A\bin\netfx 4.5.1 Tools",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\netfx 4.5.1 Tools",
+        @"C:\Program Files\Microsoft SDKs\Windows\v8.0A\bin\netfx 4.0 Tools",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A\bin\netfx 4.0 Tools",
+        @"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\netfx 4.0 Tools",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1\Bin\netfx 4.0 Tools",
+        @"C:\Program Files\Microsoft SDKs\Windows\v7.0A\bin\netfx 4.0 Tools",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\netfx 4.0 Tools",
+        @"C:\Program Files\Microsoft SDKs\Windows\v7.0A\Bin",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin",
+        @"C:\Program Files\Microsoft SDKs\Windows\v6.0A\Bin",
+        @"C:\Program Files (x86)\Microsoft SDKs\Windows\v6.0A\Bin",
+        @"C:\Program Files (x86)\Microsoft Visual Studio 8\SDK\v2.0\bin"
+    };
+
+    public static string GetSdkToolPath(string execName)
+    {
+        foreach (var path in PeVerifyProbingPaths)
+        {
+            var file = Path.Combine(path, execName);
+            if (File.Exists(file))
+            {
+                return file;
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/TestsExplicit/Helpers/Verifier.cs
+++ b/TestsExplicit/Helpers/Verifier.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+public static class Verifier
+{
+    public static void Verify(string beforeAssemblyPath, string afterAssemblyPath)
+    {
+        var before = Validate(beforeAssemblyPath);
+        var after = Validate(afterAssemblyPath);
+        var message = $"Failed processing {Path.GetFileName(afterAssemblyPath)}\r\n{after}";
+        Assert.AreEqual(TrimLineNumbers(before), TrimLineNumbers(after), message);
+    }
+
+    public static string Validate(string assemblyPath2)
+    {
+        var exePath = GetPathToPEVerify();
+        var process = Process.Start(new ProcessStartInfo(exePath, "\"" + assemblyPath2 + "\"")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+
+        process.WaitForExit(10000);
+        return process.StandardOutput.ReadToEnd().Trim().Replace(assemblyPath2, "");
+    }
+
+    static string GetPathToPEVerify()
+    {
+        var path = SdkToolsHelper.GetSdkToolPath("peverify.exe");
+        if (!File.Exists(path))
+        {
+            Assert.Ignore("PEVerify could not be found");
+        }
+        return path;
+    }
+
+    static string TrimLineNumbers(string foo)
+    {
+        return Regex.Replace(foo, "0x.*]", "");
+    }
+}

--- a/TestsExplicit/RewritingConstructors.RequiresNonNullArgument.approved.txt
+++ b/TestsExplicit/RewritingConstructors.RequiresNonNullArgument.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullArg is null.
+Parameter name: nonNullArg

--- a/TestsExplicit/RewritingConstructors.RequiresNonNullOutArgument.approved.txt
+++ b/TestsExplicit/RewritingConstructors.RequiresNonNullOutArgument.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Out parameter 'nonNullOutArg' is null.

--- a/TestsExplicit/RewritingConstructors.cs
+++ b/TestsExplicit/RewritingConstructors.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reflection;
+using ApprovalTests;
+using NUnit.Framework;
+
+[TestFixture]
+public class RewritingConstructors
+{
+    [Test]
+    public void RequiresNonNullArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var exception = Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(type, null, ""));
+        Approvals.Verify(exception.InnerException.Message);
+    }
+
+    [Test]
+    public void RequiresNonNullOutArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var args = new object[1];
+        var exception = Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(type, args));
+        Approvals.Verify(exception.InnerException.Message);
+      //  Assert.AreEqual("Fail: [NullGuard] Out parameter 'nonNullOutArg' is null.", AssemblyWeaver.TestListener.Message);
+    }
+
+    [Test]
+    public void AllowsNullWhenAttributeApplied()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        Activator.CreateInstance(type, "", null);
+    }
+
+    [Test]
+    public void AllowsNullWhenClassMatchExcludeRegex()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassToExclude");
+        Activator.CreateInstance(type, new object[]{ null });
+    }
+}

--- a/TestsExplicit/RewritingIndexers.NonNullableIndexerGetterWithFirstArgumentNull.approved.txt
+++ b/TestsExplicit/RewritingIndexers.NonNullableIndexerGetterWithFirstArgumentNull.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullParam1 is null.
+Parameter name: nonNullParam1

--- a/TestsExplicit/RewritingIndexers.NonNullableIndexerGetterWithSecondArgumentNull.approved.txt
+++ b/TestsExplicit/RewritingIndexers.NonNullableIndexerGetterWithSecondArgumentNull.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullParam2 is null.
+Parameter name: nonNullParam2

--- a/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithFirstArgumentNull.approved.txt
+++ b/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithFirstArgumentNull.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullParam1 is null.
+Parameter name: nonNullParam1

--- a/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithSecondArgumentNull.approved.txt
+++ b/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithSecondArgumentNull.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullParam2 is null.
+Parameter name: nonNullParam2

--- a/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithValueArgumentNull.approved.txt
+++ b/TestsExplicit/RewritingIndexers.NonNullableIndexerSetterWithValueArgumentNull.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] Cannot set the value of property 'System.String Indexers/NonNullable::Item(System.String,System.String)' to null.
+Parameter name: value

--- a/TestsExplicit/RewritingIndexers.PassThroughGetterReturnValueWithNullArgument.approved.txt
+++ b/TestsExplicit/RewritingIndexers.PassThroughGetterReturnValueWithNullArgument.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of property 'System.String Indexers/PassThroughGetterReturnValue::Item(System.String)' is null.

--- a/TestsExplicit/RewritingIndexers.cs
+++ b/TestsExplicit/RewritingIndexers.cs
@@ -1,0 +1,106 @@
+using System;
+using ApprovalTests;
+using NUnit.Framework;
+
+[TestFixture]
+public class RewritingIndexers
+{
+    [Test]
+    public void NonNullableIndexerSetterWithFirstArgumentNull()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: null, nonNullParam2: null] = "value");
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void NonNullableIndexerSetterWithSecondArgumentNull()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: null] = "value");
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void NonNullableIndexerSetterWithValueArgumentNull()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        var exception = Assert.Throws<ArgumentNullException>(() => instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = null);
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void NonNullableIndexerSetterWithNonNullArguments()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"] = "value";
+    }
+
+    [Test]
+    public void NonNullableIndexerGetterWithFirstArgumentNull()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: null, nonNullParam2: null]));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void NonNullableIndexerGetterWithSecondArgumentNull()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        var exception = Assert.Throws<ArgumentNullException>(() => IgnoreValue(instance[nonNullParam1: "arg 1", nonNullParam2: null]));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void NonNullableIndexerGetterWithNonNullArguments()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("NonNullable"));
+        Assert.AreEqual("return value of NonNullable", instance[nonNullParam1: "arg 1", nonNullParam2: "arg 2"]);
+    }
+
+    [Test]
+    public void PassThroughGetterReturnValueWithNullArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("PassThroughGetterReturnValue"));
+        var exception = Assert.Throws<InvalidOperationException>(() => IgnoreValue(instance[returnValue: null]));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void PassThroughGetterReturnValueWithNonNullArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("PassThroughGetterReturnValue"));
+        Assert.AreEqual("not null", instance[returnValue: "not null"]);
+    }
+
+    [Test]
+    public void AllowedNullsIndexerSetter()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("AllowedNulls"));
+        instance[allowNull: null, nullableInt: null] = null;
+    }
+
+    [Test]
+    public void AllowedNullsIndexerGetter()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("Indexers");
+        var instance = (dynamic) Activator.CreateInstance(type.GetNestedType("AllowedNulls"));
+        Assert.AreEqual(null, instance[allowNull: null, nullableInt: null]);
+    }
+
+    // ReSharper disable once UnusedParameter.Local
+    void IgnoreValue(object value)
+    {
+    }
+}

--- a/TestsExplicit/RewritingMethods.RequiresNonNullArgument.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullArgument.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullArg is null.
+Parameter name: nonNullArg

--- a/TestsExplicit/RewritingMethods.RequiresNonNullArgumentAsync.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullArgumentAsync.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] nonNullArg is null.
+Parameter name: nonNullArg

--- a/TestsExplicit/RewritingMethods.RequiresNonNullArgumentForExplicitInterface.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullArgumentForExplicitInterface.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] other is null.
+Parameter name: other

--- a/TestsExplicit/RewritingMethods.RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] x is null.
+Parameter name: x

--- a/TestsExplicit/RewritingMethods.RequiresNonNullForOptionalParameterWithNonNullDefaultValue.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullForOptionalParameterWithNonNullDefaultValue.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] optional is null.
+Parameter name: optional

--- a/TestsExplicit/RewritingMethods.RequiresNonNullGenericMethodReturnValue.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullGenericMethodReturnValue.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of method 'T SimpleClass::MethodWithGenericReturn(System.Boolean)' is null.

--- a/TestsExplicit/RewritingMethods.RequiresNonNullMethodReturnValue.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullMethodReturnValue.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of method 'System.String SimpleClass::MethodWithReturnValue(System.Boolean)' is null.

--- a/TestsExplicit/RewritingMethods.RequiresNonNullMethodReturnValueAsync.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullMethodReturnValueAsync.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of method 'System.Threading.Tasks.Task`1<System.String> SpecialClass::MethodWithReturnValueAsync(System.Boolean)' is null.

--- a/TestsExplicit/RewritingMethods.RequiresNonNullOutValue.approved.txt
+++ b/TestsExplicit/RewritingMethods.RequiresNonNullOutValue.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Out parameter 'nonNullOutArg' is null.

--- a/TestsExplicit/RewritingMethods.cs
+++ b/TestsExplicit/RewritingMethods.cs
@@ -1,0 +1,233 @@
+using System;
+using ApprovalTests;
+#if (DEBUG)
+using System.Threading.Tasks;
+#endif
+
+using NUnit.Framework;
+
+[TestFixture]
+public class RewritingMethods
+{
+    [Test]
+    public void RequiresNonNullArgumentForExplicitInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithExplicitInterface");
+        var sample = (IComparable<string>)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.CompareTo(null));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void RequiresNonNullArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.SomeMethod(null, ""));
+        Assert.AreEqual("nonNullArg", exception.ParamName);
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullWhenAttributeApplied()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.SomeMethod("", null);
+    }
+
+    [Test]
+    public void RequiresNonNullMethodReturnValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithReturnValue(true));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void RequiresNonNullGenericMethodReturnValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithGenericReturn<object>(true));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullReturnValueWhenAttributeApplied()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.MethodAllowsNullReturnValue();
+    }
+
+    [Test]
+    public void RequiresNonNullOutValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        string value;
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithOutValue(out value));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullOutValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        string value;
+        sample.MethodWithAllowedNullOutValue(out value);
+    }
+
+    [Test]
+    public void DoesNotRequireNonNullForNonPublicMethod()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.PublicWrapperOfPrivateMethod();
+    }
+
+    [Test]
+    public void DoesNotRequireNonNullForOptionalParameter()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.MethodWithOptionalParameter(optional: null);
+    }
+
+    [Test]
+    public void RequiresNonNullForOptionalParameterWithNonNullDefaultValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.MethodWithOptionalParameterWithNonNullDefaultValue(optional: null));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void DoesNotRequireNonNullForOptionalParameterWithNonNullDefaultValueButAllowNullAttribute()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.MethodWithOptionalParameterWithNonNullDefaultValueButAllowNullAttribute(optional: null);
+    }
+
+    [Test]
+    public void RequiresNonNullForNonPublicMethodWhenAttributeSpecifiesNonPublic()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithPrivateMethod");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.PublicWrapperOfPrivateMethod());
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void ReturnGuardDoesNotInterfereWithIteratorMethod()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        Assert.That(new[] { 0, 1, 2, 3, 4 }, Is.EquivalentTo(sample.CountTo(5)));
+    }
+
+#if (DEBUG)
+
+    [Test]
+    public void RequiresNonNullArgumentAsync()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.SomeMethodAsync(null, ""));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullWhenAttributeAppliedAsync()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.SomeMethodAsync("", null);
+    }
+
+    [Test]
+    public void RequiresNonNullMethodReturnValueAsync()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+
+        Exception exception = null;
+
+        ((Task<string>)sample.MethodWithReturnValueAsync(true))
+            .ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    exception = t.Exception.Flatten().InnerException;
+                }
+            })
+            .Wait();
+
+        Assert.NotNull(exception);
+        Assert.IsInstanceOf<InvalidOperationException>(exception);
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullReturnValueWhenAttributeAppliedAsync()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+
+        Exception ex = null;
+
+        ((Task<string>)sample.MethodAllowsNullReturnValueAsync())
+            .ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    ex = t.Exception.Flatten().InnerException;
+            })
+            .Wait();
+
+        Assert.Null(ex);
+    }
+
+    [Test]
+    public void NoAwaitWillCompile()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SpecialClass");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        Assert.AreEqual(42, instance.NoAwaitCode().Result);
+    }
+
+#endif
+
+    [Test]
+    public void AllowsNullWhenClassMatchExcludeRegex()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassToExclude");
+        var ClassToExclude = (dynamic)Activator.CreateInstance(type, "");
+        ClassToExclude.Test(null);
+    }
+
+    [Test]
+    public void ReturnValueChecksWithBranchToRetInstruction()
+    {
+        // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.ReturnValueChecksWithBranchToRetInstruction());
+        Assert.AreEqual("[NullGuard] Return value of method 'System.String SimpleClass::ReturnValueChecksWithBranchToRetInstruction()' is null.", exception.Message);
+    }
+
+    [Test]
+    public void OutValueChecksWithRetInstructionAsSwitchCase()
+    {
+        // This is a regression test for the "Branch to RET" issue described in https://github.com/Fody/NullGuard/issues/61.
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        string value;
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.OutValueChecksWithRetInstructionAsSwitchCase(0, out value));
+        Assert.AreEqual("[NullGuard] Out parameter 'outParam' is null.", exception.Message);
+    }
+}

--- a/TestsExplicit/RewritingProperties.GenericPropertyGetterRequiresNonNullReturnValue.approved.txt
+++ b/TestsExplicit/RewritingProperties.GenericPropertyGetterRequiresNonNullReturnValue.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of property 'T GenericClass`1::NonNullProperty()' is null.

--- a/TestsExplicit/RewritingProperties.PropertyAllowsNullGetButNotSet.approved.txt
+++ b/TestsExplicit/RewritingProperties.PropertyAllowsNullGetButNotSet.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] Cannot set the value of property 'System.String SimpleClass::NonNullProperty()' to null.
+Parameter name: value

--- a/TestsExplicit/RewritingProperties.PropertyAllowsNullSetButNotGet.approved.txt
+++ b/TestsExplicit/RewritingProperties.PropertyAllowsNullSetButNotGet.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of property 'System.String SimpleClass::PropertyAllowsNullSetButDoesNotAllowNullGet()' is null.

--- a/TestsExplicit/RewritingProperties.PropertyGetterRequiresNonNullReturnValue.approved.txt
+++ b/TestsExplicit/RewritingProperties.PropertyGetterRequiresNonNullReturnValue.approved.txt
@@ -1,0 +1,1 @@
+﻿[NullGuard] Return value of property 'System.String SimpleClass::NonNullProperty()' is null.

--- a/TestsExplicit/RewritingProperties.PropertySetterRequiresNonNullArgument.approved.txt
+++ b/TestsExplicit/RewritingProperties.PropertySetterRequiresNonNullArgument.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] Cannot set the value of property 'System.String SimpleClass::NonNullProperty()' to null.
+Parameter name: value

--- a/TestsExplicit/RewritingProperties.cs
+++ b/TestsExplicit/RewritingProperties.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using ApprovalTests;
+using NUnit.Framework;
+
+[TestFixture]
+public class RewritingProperties
+{
+    [Test]
+    public void PropertySetterRequiresNonNullArgument()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => { sample.NonNullProperty = null; });
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void PropertyGetterRequiresNonNullReturnValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            // ReSharper disable UnusedVariable
+            var temp = sample.NonNullProperty;
+
+            // ReSharper restore UnusedVariable
+        });
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void GenericPropertyGetterRequiresNonNullReturnValue()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("GenericClass`1");
+        var sample = (dynamic)Activator.CreateInstance(type.MakeGenericType(typeof(string)));
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            // ReSharper disable UnusedVariable
+            var temp = sample.NonNullProperty;
+
+            // ReSharper restore UnusedVariable
+        });
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void PropertyAllowsNullGetButNotSet()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        Assert.Null(sample.PropertyAllowsNullGetButDoesNotAllowNullSet);
+        var exception = Assert.Throws<ArgumentNullException>(() => { sample.NonNullProperty = null; });
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void PropertyAllowsNullSetButNotGet()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.PropertyAllowsNullSetButDoesNotAllowNullGet = null;
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            // ReSharper disable UnusedVariable
+            var temp = sample.PropertyAllowsNullSetButDoesNotAllowNullGet;
+
+            // ReSharper restore UnusedVariable
+        });
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void PropertySetterRequiresAllowsNullArgumentForNullableType()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.NonNullNullableProperty = null;
+    }
+
+    [Test]
+    public void DoesNotRequireNullSetterWhenPropertiesNotSpecifiedByAttribute()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithPrivateMethod");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.SomeProperty = null;
+    }
+
+    [Test]
+    public void AllowsNullWhenClassMatchExcludeRegex()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassToExclude");
+        var classToExclude = (dynamic) Activator.CreateInstance(type, "");
+        classToExclude.Property = null;
+        string result = classToExclude.Property;
+    }
+}

--- a/TestsExplicit/SetUpFixture.cs
+++ b/TestsExplicit/SetUpFixture.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+[SetUpFixture]
+public class SetUpFixture
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        FixCurrentDirectory();
+    }
+
+    void FixCurrentDirectory([CallerFilePath] string callerFilePath="")
+    {
+        Environment.CurrentDirectory = Directory.GetParent(callerFilePath).FullName;
+    }
+}

--- a/TestsExplicit/TestsExplicit.csproj
+++ b/TestsExplicit/TestsExplicit.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="*" />
+    <PackageReference Include="ApprovalUtilities" Version="*" />
+    <PackageReference Include="FodyCecil" Version="*" />
+    <PackageReference Include="NUnit" Version="*" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.CSharp" />
+    <ProjectReference Include="..\AssemblyToProcessExplicit\AssemblyToProcessExplicit.csproj" />
+    <ProjectReference Include="..\Fody\Fody.csproj" />
+  </ItemGroup>
+</Project>

--- a/TestsExplicit/VerifyTest.cs
+++ b/TestsExplicit/VerifyTest.cs
@@ -1,0 +1,15 @@
+﻿#if(DEBUG)
+
+using NUnit.Framework;
+
+[TestFixture]
+public class VerifyTest
+{
+    [Test]
+    public void PeVerify()
+    {
+        Verifier.Verify(AssemblyWeaver.BeforeAssemblyPath, AssemblyWeaver.AfterAssemblyPath);
+    }
+}
+
+#endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ build:
   project: NullGuard.sln
 
 test_script:
-  - nunit3-console Tests\bin\Release\Tests.dll --x86 --result=myresults.xml;format=AppVeyor
+  - nunit3-console Tests\bin\Release\net461\Tests.dll --x86 --result=myresults.xml;format=AppVeyor
+  - nunit3-console TestsExplicit\bin\Release\net461\TestsExplicit.dll --x86 --result=myresults.xml;format=AppVeyor
 
 artifacts:
   - path: NuGetBuild\*.nupkg


### PR DESCRIPTION
This adds the new functionality described in #67. Null guards are only added for items with an explicit `[NotNull]` attribute.

The changes in the existing program code are minimal, just added a flag to toggle between the modes and pass it to the "AllowsNull..()" extension methods.

The major change was to duplicate the test code, so the tests run for both cases.

See the updated Readme.md for how it's intended to work