### PR TITLE
Fix Issue #60

### DIFF
--- a/AssemblyToProcess/ClassWithExplicitInterface.cs
+++ b/AssemblyToProcess/ClassWithExplicitInterface.cs
@@ -1,9 +1,43 @@
 using System;
 
+using NullGuard;
+
 public class ClassWithExplicitInterface : IComparable<string>
 {
     int IComparable<string>.CompareTo(string other)
     {
         return 0;
+    }
+
+    public int CallInteralClassWithPrivateInterface([AllowNull] string other)
+    {
+        return ((IPrivate) new ClassWithExplicitPrivateInterface()).CompareTo(other);
+    }
+
+    public int CallInteralClassWithPublicInterface([AllowNull] string other)
+    {
+        return ((IComparable<string>) new ClassWithExplicitPublicInterface()).CompareTo(other);
+    }
+
+
+    private interface IPrivate
+    {
+        int CompareTo(string other);
+    }
+
+    private class ClassWithExplicitPrivateInterface : IPrivate
+    {
+        int IPrivate.CompareTo(string other1)
+        {
+            return 0;
+        }
+    }
+
+    private class ClassWithExplicitPublicInterface : IComparable<string>
+    {
+        int IComparable<string>.CompareTo(string other1)
+        {
+            return 1;
+        }
     }
 }

--- a/AssemblyToProcess/ClassWithImplicitInterface.cs
+++ b/AssemblyToProcess/ClassWithImplicitInterface.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+using NullGuard;
+
+public class ClassWithImplicitInterface : IComparable<string>
+{
+    public int CompareTo(string other)
+    {
+        return 0;
+    }
+
+    public int CallInteralClassWithPrivateInterface([AllowNull] string other)
+    {
+        return new ClassWithImplicitPrivateInterface().CompareTo(other);
+    }
+
+    public int CallInteralClassWithPublicInterface([AllowNull] string other)
+    {
+        return new ClassWithImplicitPublicInterface().CompareTo(other);
+    }
+
+    private interface IPrivate
+    {
+        int CompareTo(string other);
+    }
+
+    private class ClassWithImplicitPrivateInterface : IPrivate
+    {
+        public int CompareTo(string other1)
+        {
+            return 0;
+        }
+    }
+
+    private class ClassWithImplicitPublicInterface : IComparable<string>
+    {
+        public int CompareTo(string other1)
+        {
+            return 0;
+        }
+    }
+}

--- a/Fody/MethodProcessor.cs
+++ b/Fody/MethodProcessor.cs
@@ -38,8 +38,9 @@ public partial class ModuleWeaver
             localValidationFlags = (ValidationFlags)attribute.ConstructorArguments[0].Value;
         }
 
-        if (!localValidationFlags.HasFlag(ValidationFlags.NonPublic) &&
-            (!(method.IsPublic || method.IsExplicitInterfaceMethod()) || !method.DeclaringType.IsPublicOrNestedPublic()))
+        if (!localValidationFlags.HasFlag(ValidationFlags.NonPublic)
+            && !((method.IsPublic && method.DeclaringType.IsPublicOrNestedPublic())
+            || method.IsOverrideOrImplementationOfPublicMember()))
         {
             return;
         }

--- a/NullGuard.sln
+++ b/NullGuard.sln
@@ -26,9 +26,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithAnnotations", "AssemblyWithAnnotations\AssemblyWithAnnotations.csproj", "{E6300522-9050-43C0-8B29-9993E26415FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithAnnotations", "AssemblyWithAnnotations\AssemblyWithAnnotations.csproj", "{E6300522-9050-43C0-8B29-9993E26415FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithExternalAnnotations", "AssemblyWithExternalAnnotations\AssemblyWithExternalAnnotations.csproj", "{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithExternalAnnotations", "AssemblyWithExternalAnnotations\AssemblyWithExternalAnnotations.csproj", "{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestsCommon", "TestsCommon\TestsCommon.csproj", "{9B26DD0B-4255-428A-A7FB-D1C2142E6A37}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +70,10 @@ Global
 		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B834F8CA-7CA6-4BBE-B54F-009F38EE9064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B26DD0B-4255-428A-A7FB-D1C2142E6A37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B26DD0B-4255-428A-A7FB-D1C2142E6A37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B26DD0B-4255-428A-A7FB-D1C2142E6A37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B26DD0B-4255-428A-A7FB-D1C2142E6A37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/ApprovedTests.ClassWithExplicitInterface.approved.txt
+++ b/Tests/ApprovedTests.ClassWithExplicitInterface.approved.txt
@@ -1,0 +1,138 @@
+﻿.class public auto ansi beforefieldinit ClassWithExplicitInterface
+       extends [mscorlib]System.Object
+       implements class [mscorlib]System.IComparable`1<string>
+{
+  .class interface abstract auto ansi nested private IPrivate
+  {
+    .method public hidebysig newslot abstract virtual 
+            instance int32  CompareTo(string other) cil managed
+    {
+    } // end of method IPrivate::CompareTo
+  } 
+  .class auto ansi nested private beforefieldinit ClassWithExplicitPrivateInterface
+         extends [mscorlib]System.Object
+         implements ClassWithExplicitInterface/IPrivate
+  {
+    .method private hidebysig newslot virtual final 
+            instance int32  ClassWithExplicitInterface.IPrivate.CompareTo(string other1) cil managed
+    {
+      .override ClassWithExplicitInterface/IPrivate::CompareTo
+      // Code size       2 (0x2)
+      .maxstack  8
+      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+//000032:             return 0;
+      IL_0000:  ldc.i4.0
+      IL_0001:  ret
+    } // end of method ClassWithExplicitPrivateInterface::ClassWithExplicitInterface.IPrivate.CompareTo
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method ClassWithExplicitPrivateInterface::.ctor
+  } 
+  .class auto ansi nested private beforefieldinit ClassWithExplicitPublicInterface
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IComparable`1<string>
+  {
+    .method private hidebysig newslot virtual final 
+            instance int32  'System.IComparable<System.String>.CompareTo'(string other1) cil managed
+    {
+      .override  method instance int32 class [mscorlib]System.IComparable`1<string>::CompareTo(!0)
+      // Code size       21 (0x15)
+      .maxstack  2
+//000033:         }
+//000034:     }
+//000035: 
+//000036:     private class ClassWithExplicitPublicInterface : IComparable<string>
+//000037:     {
+//000038:         int IComparable<string>.CompareTo(string other1)
+//000039:         {
+//000040:             return 0;
+//000041:         }
+//000042:     }
+//000043: }
+      IL_0000:  ldarg.1
+      IL_0001:  brtrue.s   IL_0013
+      IL_0003:  ldstr      "other1"
+      IL_0008:  ldstr      "[NullGuard] other1 is null."
+      IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0012:  throw
+//000040:             return 0;
+      IL_0013:  ldc.i4.0
+      IL_0014:  ret
+    } // end of method ClassWithExplicitPublicInterface::'System.IComparable<System.String>.CompareTo'
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method ClassWithExplicitPublicInterface::.ctor
+  } 
+  .method private hidebysig newslot virtual final 
+          instance int32  'System.IComparable<System.String>.CompareTo'(string other) cil managed
+  {
+    .override  method instance int32 class [mscorlib]System.IComparable`1<string>::CompareTo(!0)
+    // Code size       21 (0x15)
+    .maxstack  2
+//000041:         }
+//000042:     }
+//000043: }
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "other"
+    IL_0008:  ldstr      "[NullGuard] other is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+//000009:         return 0;
+    IL_0013:  ldc.i4.0
+    IL_0014:  ret
+  } 
+  .method public hidebysig instance int32 
+          CallInteralClassWithPrivateInterface(string other) cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  2
+//000010:     }
+//000011: 
+//000012:     public int CallInteralClassWithPrivateInterface([AllowNull] string other)
+//000013:     {
+//000014:         return ((IPrivate) new ClassWithExplicitPrivateInterface()).CompareTo(other);
+    IL_0000:  newobj     instance void ClassWithExplicitInterface/ClassWithExplicitPrivateInterface::.ctor()
+    IL_0005:  ldarg.1
+    IL_0006:  callvirt   instance int32 ClassWithExplicitInterface/IPrivate::CompareTo(string)
+    IL_000b:  ret
+  } 
+  .method public hidebysig instance int32 
+          CallInteralClassWithPublicInterface(string other) cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  2
+//000015:     }
+//000016: 
+//000017:     public int CallInteralClassWithPublicInterface([AllowNull] string other)
+//000018:     {
+//000019:         return ((IComparable<string>) new ClassWithExplicitPublicInterface()).CompareTo(other);
+    IL_0000:  newobj     instance void ClassWithExplicitInterface/ClassWithExplicitPublicInterface::.ctor()
+    IL_0005:  ldarg.1
+    IL_0006:  callvirt   instance int32 class [mscorlib]System.IComparable`1<string>::CompareTo(!0)
+    IL_000b:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/Tests/ApprovedTests.ClassWithImplicitInterface.approved.txt
+++ b/Tests/ApprovedTests.ClassWithImplicitInterface.approved.txt
@@ -1,0 +1,135 @@
+﻿.class public auto ansi beforefieldinit ClassWithImplicitInterface
+       extends [mscorlib]System.Object
+       implements class [mscorlib]System.IComparable`1<string>
+{
+  .class interface abstract auto ansi nested private IPrivate
+  {
+    .method public hidebysig newslot abstract virtual 
+            instance int32  CompareTo(string other) cil managed
+    {
+    } // end of method IPrivate::CompareTo
+  } 
+  .class auto ansi nested private beforefieldinit ClassWithImplicitPrivateInterface
+         extends [mscorlib]System.Object
+         implements ClassWithImplicitInterface/IPrivate
+  {
+    .method public hidebysig newslot virtual final 
+            instance int32  CompareTo(string other1) cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      .language '{3F5162F8-07C6-11D3-9053-00C04FA302A1}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+//000031:             return 0;
+      IL_0000:  ldc.i4.0
+      IL_0001:  ret
+    } // end of method ClassWithImplicitPrivateInterface::CompareTo
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method ClassWithImplicitPrivateInterface::.ctor
+  } 
+  .class auto ansi nested private beforefieldinit ClassWithImplicitPublicInterface
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IComparable`1<string>
+  {
+    .method public hidebysig newslot virtual final 
+            instance int32  CompareTo(string other1) cil managed
+    {
+      // Code size       21 (0x15)
+      .maxstack  2
+//000032:         }
+//000033:     }
+//000034: 
+//000035:     private class ClassWithImplicitPublicInterface : IComparable<string>
+//000036:     {
+//000037:         public int CompareTo(string other1)
+//000038:         {
+//000039:             return 0;
+//000040:         }
+//000041:     }
+//000042: }
+      IL_0000:  ldarg.1
+      IL_0001:  brtrue.s   IL_0013
+      IL_0003:  ldstr      "other1"
+      IL_0008:  ldstr      "[NullGuard] other1 is null."
+      IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                       string)
+      IL_0012:  throw
+//000039:             return 0;
+      IL_0013:  ldc.i4.0
+      IL_0014:  ret
+    } // end of method ClassWithImplicitPublicInterface::CompareTo
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method ClassWithImplicitPublicInterface::.ctor
+  } 
+  .method public hidebysig newslot virtual final 
+          instance int32  CompareTo(string other) cil managed
+  {
+    // Code size       21 (0x15)
+    .maxstack  2
+//000040:         }
+//000041:     }
+//000042: }
+    IL_0000:  ldarg.1
+    IL_0001:  brtrue.s   IL_0013
+    IL_0003:  ldstr      "other"
+    IL_0008:  ldstr      "[NullGuard] other is null."
+    IL_000d:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string,
+                                                                                     string)
+    IL_0012:  throw
+//000009:         return 0;
+    IL_0013:  ldc.i4.0
+    IL_0014:  ret
+  } 
+  .method public hidebysig instance int32 
+          CallInteralClassWithPrivateInterface(string other) cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  2
+//000010:     }
+//000011: 
+//000012:     public int CallInteralClassWithPrivateInterface([AllowNull] string other)
+//000013:     {
+//000014:         return new ClassWithImplicitPrivateInterface().CompareTo(other);
+    IL_0000:  newobj     instance void ClassWithImplicitInterface/ClassWithImplicitPrivateInterface::.ctor()
+    IL_0005:  ldarg.1
+    IL_0006:  call       instance int32 ClassWithImplicitInterface/ClassWithImplicitPrivateInterface::CompareTo(string)
+    IL_000b:  ret
+  } 
+  .method public hidebysig instance int32 
+          CallInteralClassWithPublicInterface(string other) cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  2
+//000015:     }
+//000016: 
+//000017:     public int CallInteralClassWithPublicInterface([AllowNull] string other)
+//000018:     {
+//000019:         return new ClassWithImplicitPublicInterface().CompareTo(other);
+    IL_0000:  newobj     instance void ClassWithImplicitInterface/ClassWithImplicitPublicInterface::.ctor()
+    IL_0005:  ldarg.1
+    IL_0006:  call       instance int32 ClassWithImplicitInterface/ClassWithImplicitPublicInterface::CompareTo(string)
+    IL_000b:  ret
+  } 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } 
+}

--- a/Tests/ApprovedTests.cs
+++ b/Tests/ApprovedTests.cs
@@ -80,6 +80,24 @@ public class ApprovedTests
     }
 
     [Test]
+    public void ClassWithImplicitInterface()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithImplicitInterface"));
+    }
+
+    [Test]
+    public void ClassWithExplicitInterface()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithExplicitInterface"));
+    }
+
+    [Test]
+    public void ClassWithExplicitInterface_ClassWithExplicitPublicInterface()
+    {
+        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithExplicitInterface/ClassWithExplicitPublicInterface"));
+    }
+
+    [Test]
     public void InfosList()
     {
         Approvals.VerifyAll(AssemblyWeaver.Infos.OrderBy(e => e), "Infos: ");

--- a/Tests/ApprovedTests.cs
+++ b/Tests/ApprovedTests.cs
@@ -92,12 +92,6 @@ public class ApprovedTests
     }
 
     [Test]
-    public void ClassWithExplicitInterface_ClassWithExplicitPublicInterface()
-    {
-        Approvals.Verify(Decompiler.Decompile(AssemblyWeaver.AfterAssemblyPath, "ClassWithExplicitInterface/ClassWithExplicitPublicInterface"));
-    }
-
-    [Test]
     public void InfosList()
     {
         Approvals.VerifyAll(AssemblyWeaver.Infos.OrderBy(e => e), "Infos: ");

--- a/Tests/RewritingMethods.RequiresNonNullArgumentForImplicitInterface.approved.txt
+++ b/Tests/RewritingMethods.RequiresNonNullArgumentForImplicitInterface.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] other is null.
+Parameter name: other

--- a/Tests/RewritingMethods.RequiresNonNullArgumentForInternalClassWithExplicitPublicInterface.approved.txt
+++ b/Tests/RewritingMethods.RequiresNonNullArgumentForInternalClassWithExplicitPublicInterface.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] other1 is null.
+Parameter name: other1

--- a/Tests/RewritingMethods.RequiresNonNullArgumentForInternalClassWithImplicitPublicInterface.approved.txt
+++ b/Tests/RewritingMethods.RequiresNonNullArgumentForInternalClassWithImplicitPublicInterface.approved.txt
@@ -1,0 +1,2 @@
+﻿[NullGuard] other1 is null.
+Parameter name: other1

--- a/Tests/RewritingMethods.cs
+++ b/Tests/RewritingMethods.cs
@@ -19,6 +19,49 @@ public class RewritingMethods
     }
 
     [Test]
+    public void RequiresNonNullArgumentForInternalClassWithExplicitPublicInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithExplicitInterface");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.CallInteralClassWithPublicInterface(null));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullForInternalClassWithExplicitPrivateInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithExplicitInterface");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        Assert.DoesNotThrow(() => sample.CallInteralClassWithPrivateInterface(null));
+    }
+
+    [Test]
+    public void RequiresNonNullArgumentForImplicitInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithImplicitInterface");
+        var sample = (IComparable<string>)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.CompareTo(null));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void RequiresNonNullArgumentForInternalClassWithImplicitPublicInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithImplicitInterface");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => sample.CallInteralClassWithPublicInterface(null));
+        Approvals.Verify(exception.Message);
+    }
+
+    [Test]
+    public void AllowsNullForInternalClassWithImplicitPrivateInterface()
+    {
+        var type = AssemblyWeaver.Assembly.GetType("ClassWithImplicitInterface");
+        var sample = (dynamic)Activator.CreateInstance(type);
+        Assert.DoesNotThrow(() => sample.CallInteralClassWithPrivateInterface(null));
+    }
+
+    [Test]
     public void RequiresNonNullArgument()
     {
         var type = AssemblyWeaver.Assembly.GetType("SimpleClass");

--- a/TestsCommon/InheritanceTests.cs
+++ b/TestsCommon/InheritanceTests.cs
@@ -1,0 +1,483 @@
+﻿namespace TestsCommon
+{
+    using System;
+    using System.Linq;
+
+    using Mono.Cecil;
+
+    using NullGuard;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class InheritanceTests
+    {
+        ModuleDefinition _module = ModuleDefinition.ReadModule(typeof(InheritanceTests).Assembly.Location);
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsExplicitImplementedInterfaceMethods()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithExplicitInterfaceImplentation));
+            var methods = type.Methods.Where(m => m.Name.EndsWith(nameof(IComparable.CompareTo))).ToArray();
+            Assert.AreEqual(2, methods.Length);
+
+            var result = methods.SelectMany(method => method.EnumerateOverridesAndImplementations());
+            var expected = "System.Int32 System.IComparable`1::CompareTo(T)|System.Int32 System.IComparable`1::CompareTo(T)";
+            var actual = string.Join("|", result);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsImplicitImplementedInterfaceMethodss()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithImplicitInterfaceImplementation));
+            var methods = type.Methods.Where(m => m.Name.EndsWith(nameof(IComparable.CompareTo))).ToArray();
+            Assert.AreEqual(2, methods.Length);
+
+            var result = methods.SelectMany(method => method.EnumerateOverridesAndImplementations());
+            var expected = "System.Int32 System.IComparable`1::CompareTo(T)|System.Int32 System.IComparable`1::CompareTo(T)";
+            var actual = string.Join("|", result);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectImplementedInterfaceMethodsWhenClassHasBothExplicitAndImplicitImplementations()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithExplicitAndImplicitInterfaceImplementation));
+            var methods = type.Methods.Where(m => m.Name.EndsWith(nameof(IComparable.CompareTo))).ToArray();
+            Assert.AreEqual(3, methods.Length);
+
+            var interfaceMethods = methods.SelectMany(method => method.EnumerateOverridesAndImplementations()).ToArray();
+            Assert.AreEqual(2, interfaceMethods.Length);
+
+            var result = methods.SelectMany(method => method.EnumerateOverridesAndImplementations());
+            var expected = "System.Int32 System.IComparable`1::CompareTo(T)|System.Int32 System.IComparable`1::CompareTo(T)";
+            var actual = string.Join("|", result);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectMethodOnClassWithMixedGenericInterfaces()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces));
+            var method = type.Methods.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces.Method)) && m.ReturnType == _module.TypeSystem.Boolean);
+
+            var result = method.EnumerateOverridesAndImplementations();
+
+            var actual = string.Join("|", result);
+            var expected = "U3 TestsCommon.IGenericDerivedInterface`3::Method(U2)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectMethodOnDerivedClassWithMixedGenericInterfacesWhereOriginalImplementationIsOnBaseClass()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(DerivedClassClassWithMixedGenericInterfaces));
+            var methods = type.Methods.Where(m => !m.IsSpecialName);
+
+            var result = methods.SelectMany(m => m.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "System.Int32 TestsCommon.BaseClassWithMixedGenericInterfaces::Method(System.Boolean)|T2 TestsCommon.IGenericBaseInterface`2::Method(T1)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectPropertyOnDerivedClassWithMixedGenericInterfacesWhereOriginalImplementationIsOnBaseClass()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(DerivedClassClassWithMixedGenericInterfaces));
+            var methods = type.Properties;
+
+            var result = methods.SelectMany(m => m.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "System.Boolean TestsCommon.BaseClassWithMixedGenericInterfaces::Property()";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectMethodFromBaseInterfaceOnClassWithMixedGenericInterfaces()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces));
+            var method = type.Methods.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces.Method)) && m.ReturnType == _module.TypeSystem.Int32);
+
+            var result = method.EnumerateOverridesAndImplementations();
+
+            var actual = string.Join("|", result);
+            var expected = "T2 TestsCommon.IGenericBaseInterface`2::Method(T1)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectMethodOnClassWithMixedGenericInterfaces2()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces2));
+            var method = type.Methods.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces2.Method)) && m.Parameters[0].ParameterType == _module.TypeSystem.Int32);
+
+            var result = method.EnumerateOverridesAndImplementations();
+
+            var actual = string.Join("|", result);
+            var expected = "U3 TestsCommon.IGenericDerivedInterface2`3::Method(U2)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsCorrectMethodFromBaseInterfaceOnClassWithMixedGenericInterfaces2()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces2));
+            var method = type.Methods.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces2.Method)) && m.Parameters[0].ParameterType == _module.TypeSystem.String);
+
+            var result = method.EnumerateOverridesAndImplementations();
+
+            var actual = string.Join("|", result);
+            var expected = "T2 TestsCommon.IGenericBaseInterface`2::Method(T1)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsNoMethodFromBaseInterfaceOnClassWithMixedGenericInterfacesWhenExplictImplementationExists()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces3));
+            var method = type.Methods.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces3.Method)) && m.Parameters[0].ParameterType == _module.TypeSystem.String);
+
+            var result = method.EnumerateOverridesAndImplementations();
+            Assert.AreEqual(0, result.Count());
+        }
+
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsNoPropertyFromBaseInterfaceOnClassWithMixedGenericInterfacesWhenExplictImplementationExists()
+        {
+            var type = _module.GetTypes().Single(t => t.Name == nameof(ClassWithMixedGenericInterfaces3));
+            var property = type.Properties.Single(m => m.Name.Equals(nameof(ClassWithMixedGenericInterfaces3.Property)));
+
+            var result = property.EnumerateOverridesAndImplementations();
+            Assert.AreEqual(0, result.Count());
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsBaseMembersForMethodOverrides1()
+        {
+            var type = _module.GetTypes().Single(t => t.Name.Contains(nameof(DerivedGenericClass1<string>)));
+            var values = type.Methods.Where(m => !m.IsSpecialName);
+
+            var result = values.SelectMany(item => item.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "T2 TestsCommon.GenericBaseClass`2::Method(T1)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsBaseMembersForMethodOverrides2()
+        {
+            var type = _module.GetTypes().Single(t => t.Name.Contains(nameof(DerivedGenericClass2<string>)));
+            var values = type.Methods.Where(m => !m.IsSpecialName);
+
+            var result = values.SelectMany(item => item.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "T1 TestsCommon.GenericBaseClass`2::Method(T2)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsBaseMembersForMethodOverridesInDerivedDerived()
+        {
+            var type = _module.GetTypes().Single(t => t.Name.Contains(nameof(DerivedDerivedClass)));
+            var values = type.Methods.Where(m => !m.IsSpecialName);
+
+            var result = values.SelectMany(item => item.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "T1 TestsCommon.GenericBaseClass`2::Method(T2)";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsBaseMembersForPropertyOverrides()
+        {
+            var type = _module.GetTypes().Single(t => t.Name.Contains(nameof(DerivedGenericClass2<string>)));
+            var values = type.Properties;
+
+            var result = values.SelectMany(item => item.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "T1 TestsCommon.GenericBaseClass`2::Property()";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EnumerateOverridesAndImplementationsFindsBaseMembersForPropertyOverridesInDerivedDerived()
+        {
+            var type = _module.GetTypes().Single(t => t.Name.Contains(nameof(DerivedDerivedClass)));
+            var values = type.Properties;
+
+            var result = values.SelectMany(item => item.EnumerateOverridesAndImplementations());
+
+            var actual = string.Join("|", result);
+            var expected = "T1 TestsCommon.GenericBaseClass`2::Property()";
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+    public class ClassWithExplicitInterfaceImplentation : IComparable<string>, IComparable<int>
+    {
+        int IComparable<string>.CompareTo(string other)
+        {
+            return 0;
+        }
+
+        int IComparable<int>.CompareTo(int other)
+        {
+            return 0;
+        }
+    }
+
+    public class ClassWithImplicitInterfaceImplementation : IComparable<string>, IComparable<int>
+    {
+        public int CompareTo(string other)
+        {
+            return 0;
+        }
+
+        public int CompareTo(int other)
+        {
+            return 0;
+        }
+    }
+
+    public class ClassWithExplicitAndImplicitInterfaceImplementation : IComparable<string>, IComparable<int>
+    {
+        int IComparable<string>.CompareTo(string other)
+        {
+            return 0;
+        }
+
+        public int CompareTo(string other)
+        {
+            return 0;
+        }
+
+        public int CompareTo(int other)
+        {
+            return 0;
+        }
+    }
+
+    public interface IGenericBaseInterface<T1, T2>
+    {
+        T2 Method(T1 param);
+
+        T1 Property { get; set; }
+    }
+
+    public interface IGenericDerivedInterface<U1, U2, U3> : IGenericBaseInterface<U3, U2>
+    {
+        U1 DerivedMethod(U3 derivedParam);
+
+        U3 Method(U2 param);
+    }
+
+    public interface IGenericDerivedInterface2<U1, U2, U3> : IGenericBaseInterface<U1, U3>
+    {
+        U1 DerivedMethod(U3 derivedParam);
+
+        U3 Method(U2 param);
+    }
+
+    public class ClassWithMixedGenericInterfaces : IGenericDerivedInterface<string, int, bool>
+    {
+        public int Method(bool param)
+        {
+            return 0;
+        }
+
+        bool IGenericBaseInterface<bool, int>.Property
+        {
+            get;
+            set;
+        }
+
+        string IGenericDerivedInterface<string, int, bool>.DerivedMethod(bool derivedParam)
+        {
+            return default(string);
+        }
+
+        public bool Method(int param)
+        {
+            return false;
+        }
+    }
+
+    public class ClassWithMixedGenericInterfaces2 : IGenericDerivedInterface2<string, int, bool>
+    {
+        public bool Method(string param)
+        {
+            return false;
+        }
+
+        string IGenericBaseInterface<string, bool>.Property { get; set; }
+
+        string IGenericDerivedInterface2<string, int, bool>.DerivedMethod(bool derivedParam)
+        {
+            return default(string);
+        }
+
+        public bool Method(int param)
+        {
+            return false;
+        }
+
+
+    }
+
+    public class ClassWithMixedGenericInterfaces3 : IGenericDerivedInterface2<string, int, bool>
+    {
+        public bool Method(string param)
+        {
+            return false;
+        }
+
+        bool IGenericBaseInterface<string, bool>.Method(string param)
+        {
+            return false;
+        }
+
+        string IGenericBaseInterface<string, bool>.Property { get; set; }
+
+        public string Property { get; set; }
+
+        string IGenericDerivedInterface2<string, int, bool>.DerivedMethod(bool derivedParam)
+        {
+            return default(string);
+        }
+
+        public bool Method(int param)
+        {
+            return false;
+        }
+    }
+
+    public class BaseClassWithMixedGenericInterfaces : IGenericDerivedInterface<string, int, bool>
+    {
+        public virtual int Method(bool param)
+        {
+            return 0;
+        }
+
+        bool IGenericBaseInterface<bool, int>.Property
+        {
+            get;
+            set;
+        }
+
+        string IGenericDerivedInterface<string, int, bool>.DerivedMethod(bool derivedParam)
+        {
+            return default(string);
+        }
+
+        public virtual bool Property { get; set; }
+
+        public bool Method(int param)
+        {
+            return false;
+        }
+    }
+
+    public class DerivedClassClassWithMixedGenericInterfaces : BaseClassWithMixedGenericInterfaces
+    {
+        public override int Method(bool param)
+        {
+            return 1;
+        }
+
+        public string Method(string param)
+        {
+            return default;
+        }
+
+        public override bool Property { get; set; }
+    }
+
+    public class GenericBaseClass<T1, T2>
+    {
+        public virtual T2 Method(T1 param)
+        {
+            return default;
+        }
+
+        public virtual T1 Method(T2 param)
+        {
+            return default;
+        }
+
+        public virtual T1 Property { get; set; }
+    }
+
+    internal class DerivedGenericClass1<T> : GenericBaseClass<string, T>
+    {
+        public override T Method(string param)
+        {
+            return base.Method(param + "1");
+        }
+
+        public override string Property
+        {
+            get
+            {
+                return base.Property + "1";
+            }
+            set
+            {
+                base.Property = value;
+            }
+        }
+    }
+
+    internal class DerivedGenericClass2<T> : GenericBaseClass<string, T>
+    {
+        public override string Method(T param)
+        {
+            return base.Method(default(T));
+        }
+        public override string Property
+        {
+            get
+            {
+                return base.Property + "1";
+            }
+            set
+            {
+                base.Property = value;
+            }
+        }
+    }
+
+    internal class EmptyDerivedClass<Q> : GenericBaseClass<int, Q>
+    {
+    }
+
+    internal class DerivedDerivedClass : EmptyDerivedClass<string>
+    {
+        public override int Method(string param)
+        {
+            return base.Method(param + "1");
+        }
+
+        public override int Property
+        {
+            get
+            {
+                return base.Property + 1;
+            }
+            set
+            {
+                base.Property = value;
+            }
+        }
+    }
+}

--- a/TestsCommon/TestsCommon.csproj
+++ b/TestsCommon/TestsCommon.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="*" />
+    <PackageReference Include="ApprovalUtilities" Version="*" />
+    <PackageReference Include="FodyCecil" Version="*" />
+    <PackageReference Include="NUnit" Version="*" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.CSharp" />
+    <ProjectReference Include="..\AssemblyToProcessExplicit\AssemblyToProcessExplicit.csproj" />
+    <ProjectReference Include="..\Fody\Fody.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #60, Fix #37: A method or property is considered public if it overrides or implements a public member.