### PR TITLE
Fix #93: ReferenceFinder should return public types only

### DIFF
--- a/Fody/ReferenceFinder.cs
+++ b/Fody/ReferenceFinder.cs
@@ -16,7 +16,7 @@ public partial class ModuleWeaver
 
             if (assembly != null)
             {
-                types.AddRange(assembly.MainModule.Types);
+                types.AddRange(assembly.MainModule.Types.Where(type => type.IsPublic));
             }
         }
         catch (AssemblyResolutionException)


### PR DESCRIPTION
@SimonCropp I think this should fix #93, but I can't prove it. 
However it should not have any negative side effects. 
Any concerns?