### PR TITLE
ExcludeRegex is now working with base classes.

### DIFF
--- a/AssemblyToProcess/ClassToExclude_Derived.cs
+++ b/AssemblyToProcess/ClassToExclude_Derived.cs
@@ -1,0 +1,7 @@
+﻿public class ClassToExclude_Derived : ClassToExclude
+{
+    public ClassToExclude_Derived(string test)
+        : base(test)
+    {
+    }
+}

--- a/NullGuard.Fody/CecilExtensions.cs
+++ b/NullGuard.Fody/CecilExtensions.cs
@@ -8,6 +8,15 @@ static class CecilExtensions
     const string AllowNullAttributeTypeName = "AllowNullAttribute";
     const string CanBeNullAttributeTypeName = "CanBeNullAttribute";
 
+    public static bool FromBaseType(this TypeDefinition type, TypeDefinition baseTypeDefinition)
+    {
+        return
+            type == baseTypeDefinition ||
+            (
+                type.BaseType != null && type.BaseType.Resolve().FromBaseType(baseTypeDefinition)
+            );
+    }
+
     public static bool HasInterface(this TypeDefinition type, string interfaceFullName)
     {
         return type.Interfaces.Any(i => i.InterfaceType.FullName.Equals(interfaceFullName))

--- a/Tests/AssemblyWeaver.cs
+++ b/Tests/AssemblyWeaver.cs
@@ -13,6 +13,7 @@ public static class AssemblyWeaver
         var weavingTask = new ModuleWeaver
         {
             Config = new XElement("NullGuard",
+                new XAttribute("RegexIsForBaseClass", "1"),
                 new XAttribute("IncludeDebugAssert", false),
                 new XAttribute("ExcludeRegex", "^ClassToExclude$")),
             DefineConstants = new List<string> {"DEBUG"} // Always testing the debug weaver

--- a/Tests/RewritingConstructors.cs
+++ b/Tests/RewritingConstructors.cs
@@ -41,4 +41,28 @@ public class RewritingConstructors
         var type = AssemblyWeaver.Assembly.GetType("ClassToExclude");
         Activator.CreateInstance(type, new object[]{ null });
     }
+
+    [Fact]
+    public void AllowsNullWhenBaseClassMatchExcludeRegex()
+    {
+        try
+        {
+            var type = AssemblyWeaver.Assembly.GetType("ClassToExclude");
+            Activator.CreateInstance(type, new object[] { null });
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("BaseClass", ex);
+        }
+
+        try
+        {
+            var typeDerived = AssemblyWeaver.Assembly.GetType("ClassToExclude_Derived");
+            Activator.CreateInstance(typeDerived, new object[] { null });
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("DerivedClass", ex);
+        }
+    }
 }


### PR DESCRIPTION
New config attribute introduced: "RegexIsForBaseClass". It can be "true" / "false", "0" / "1"
CecilExtensions now has a method `FromBaseType`, which checks a type is from a base type.
`ModeuleWeaver.GetTypesToProcess` now checks a type's base class when `RegexIsForBaseClass` is set.
New test method & a test class introduced: `[Fact]AllowsNullWhenBaseClassMatchExcludeRegex` & `public class ClassToExclude_Derived`

Issue #104