### PR TITLE
Supporting C# 8 Nullable Reference Type attributes

### DIFF
--- a/AssemblyToProcess/NullableReferenceTypeClass.cs
+++ b/AssemblyToProcess/NullableReferenceTypeClass.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+public class NullableReferenceTypeClass
+{
+    /*
+    public void SomeMethod(string nonNullArg, [Nullable(2)] string nullArg)
+    {
+        Console.WriteLine(nonNullArg);
+    }
+    */
+    public void SomeMethod(string nonNullArg, string? nullArg)
+    {
+        Console.WriteLine(nonNullArg);
+    }
+
+    public string MethodWithReturnValue(bool returnNull)
+    {
+#pragma warning disable CS8603 // Possible null reference return.
+        return returnNull ? null : "";
+#pragma warning restore CS8603 // Possible null reference return.
+    }
+
+    /*
+    [NullableContext(2)]
+    public string MethodAllowsNullReturnValue()
+    {
+        return (string) null;
+    }
+    */
+    public string? MethodAllowsNullReturnValue()
+    {
+        return null;
+    }
+}
+#nullable disable

--- a/Tests/RewritingMethods.RequiresNonNullArgumentWhenNullableReferenceTypeNotUsed.verified.txt
+++ b/Tests/RewritingMethods.RequiresNonNullArgumentWhenNullableReferenceTypeNotUsed.verified.txt
@@ -1,0 +1,2 @@
+[NullGuard] nonNullArg is null.
+Parameter name: nonNullArg

--- a/Tests/RewritingMethods.RequiresNonNullMethodReturnValueWhenNullableReferenceTypeNotUsed.verified.txt
+++ b/Tests/RewritingMethods.RequiresNonNullMethodReturnValueWhenNullableReferenceTypeNotUsed.verified.txt
@@ -1,0 +1,1 @@
+[NullGuard] Return value of method 'System.String NullableReferenceTypeClass::MethodWithReturnValue(System.Boolean)' is null.

--- a/Tests/RewritingMethods.cs
+++ b/Tests/RewritingMethods.cs
@@ -78,10 +78,37 @@ public class RewritingMethods :
     }
 
     [Fact]
+    public Task RequiresNonNullArgumentWhenNullableReferenceTypeNotUsed()
+    {
+        var type = AssemblyWeaver.Assembly.GetType(nameof(NullableReferenceTypeClass));
+        var sample = (dynamic)Activator.CreateInstance(type);
+        var exception = Assert.Throws<ArgumentNullException>(() => { sample.SomeMethod(null, ""); });
+        Assert.Equal("nonNullArg", exception.ParamName);
+        return Verify(exception.Message);
+    }
+
+    [Fact]
+    public void AllowsNullWhenNullableReferenceTypeUsed()
+    {
+        var type = AssemblyWeaver.Assembly.GetType(nameof(NullableReferenceTypeClass));
+        var sample = (dynamic)Activator.CreateInstance(type);
+        sample.SomeMethod("", null);
+    }
+
+    [Fact]
     public Task RequiresNonNullMethodReturnValue()
     {
         var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
         var sample = (dynamic) Activator.CreateInstance(type);
+        var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithReturnValue(true));
+        return Verify(exception.Message);
+    }
+
+    [Fact]
+    public Task RequiresNonNullMethodReturnValueWhenNullableReferenceTypeNotUsed()
+    {
+        var type = AssemblyWeaver.Assembly.GetType(nameof(NullableReferenceTypeClass));
+        var sample = (dynamic)Activator.CreateInstance(type);
         var exception = Assert.Throws<InvalidOperationException>(() => sample.MethodWithReturnValue(true));
         return Verify(exception.Message);
     }
@@ -100,6 +127,14 @@ public class RewritingMethods :
     {
         var type = AssemblyWeaver.Assembly.GetType("SimpleClass");
         var sample = (dynamic) Activator.CreateInstance(type);
+        sample.MethodAllowsNullReturnValue();
+    }
+
+    [Fact]
+    public void AllowsNullReturnValueWhenNullableReferenceType()
+    {
+        var type = AssemblyWeaver.Assembly.GetType(nameof(NullableReferenceTypeClass));
+        var sample = (dynamic)Activator.CreateInstance(type);
         sample.MethodAllowsNullReturnValue();
     }
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The `Install-Package Fody` is required since NuGet always defaults to the oldest
 
 NullGuard supports two modes of operations, [*implicit*](#implicit-mode) and [*explicit*](#explicit-mode).
 
- * In [*implicit*](#implicit-mode) mode everything is assumed to be not-null, unless attributed with `[AllowNull]`. This is how NullGuard has been working always.
+ * In [*implicit*](#implicit-mode) mode everything is assumed to be not-null, unless attributed with `[AllowNull]`. This is how NullGuard has been working always. C# 8 nullable reference types are also used to determine if a type may be null.
  * In the new [*explicit*](#explicit-mode) mode everything is assumed to be nullable, unless attributed with `[NotNull]`. This mode is designed to support the R# nullability analysis, using pessimistic mode.
 
 If not configured explicitly, NullGuard will auto-detect the mode as follows:
@@ -50,6 +50,11 @@ public class Sample
         // arg may be null here
     }
 
+    public void AndAnotherMethod(string? arg)
+    {
+        // arg may be null here
+    }
+
     public string MethodWithReturn()
     {
         return SomeOtherClass.SomeMethod();
@@ -57,6 +62,11 @@ public class Sample
 
     [return: AllowNull]
     public string MethodAllowsNullReturnValue()
+    {
+        return null;
+    }
+
+    public string? MethodAlsoAllowsNullReturnValue()
     {
         return null;
     }
@@ -104,6 +114,11 @@ public class SampleOutput
         return null;
     }
 
+    public string MethodAlsoAllowsNullReturnValue()
+    {
+        return null;
+    }
+
     string someProperty;
     public string SomeProperty
     {
@@ -126,6 +141,10 @@ public class SampleOutput
     }
 
     public void AnotherMethod(string arg)
+    {
+    }
+
+    public void AndAnotherMethod(string arg)
     {
     }
 


### PR DESCRIPTION
- Method parameters and return values that use nullable reference types don't have null guards inserted

Implements #203

 * [x] Related issues
 * [x] Tests
 * [x] Documentation