### PR TITLE
Use script to run tests

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -4,6 +4,12 @@
     <DisableFody>true</DisableFody>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>  
+  <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="XunitContext" Version="1.8.0" />

--- a/Tests/xunit.runner.json
+++ b/Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy":  false 
+}

--- a/TestsCommon/TestsCommon.csproj
+++ b/TestsCommon/TestsCommon.csproj
@@ -5,6 +5,12 @@
     <DisableFody>true</DisableFody>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>  
+  <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="XunitContext" Version="1.8.0" />

--- a/TestsCommon/xunit.runner.json
+++ b/TestsCommon/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy":  false 
+}

--- a/TestsExplicit/TestsExplicit.csproj
+++ b/TestsExplicit/TestsExplicit.csproj
@@ -4,6 +4,12 @@
     <DisableFody>true</DisableFody>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="XunitContext" Version="1.8.0" />
     <PackageReference Include="Verify.Xunit" Version="1.22.1" />
     <PackageReference Include="FodyHelpers" Version="6.1.1" />

--- a/TestsExplicit/xunit.runner.json
+++ b/TestsExplicit/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy":  false 
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,14 @@ skip_commits:
   message: /doco|Merge pull request.*/
 build_script:
 - cmd: dotnet build --configuration Release
-test:
-  assemblies:
-    - '**\*Tests.dll'
+# test:
+#   assemblies:
+#     only:
+# #      - '**\Tests*.dll'
+#       - '**\TestsNullableRefTypes.dll'
+
+test_script:
+  - ps: .\tests.ps1 Release
+
 artifacts:
 - path: nugets\**\*.nupkg

--- a/tests.ps1
+++ b/tests.ps1
@@ -13,7 +13,6 @@ $failed = $false
 # Find each test project and run tests and upload results to AppVeyor
 Get-ChildItem .\**\*.csproj -Recurse | 
     Where-Object { $_.Name.StartsWith("Tests") } |
-    Where-Object { $_.BaseName -ne "TestsExplicit" } |
     ForEach-Object { 
 
         # Run dotnet test on the project and output the results in mstest format (also works for other frameworks like nunit)

--- a/tests.ps1
+++ b/tests.ps1
@@ -1,0 +1,40 @@
+# Based on https://stackoverflow.com/a/49019179/25702
+<#
+.SYNOPSIS
+    Runs test projects (all target platforms) and uploads results to AppVeyor
+#>
+param (
+    [string]
+    $Config = "Debug"
+)
+
+$failed = $false
+
+# Find each test project and run tests and upload results to AppVeyor
+Get-ChildItem .\**\*.csproj -Recurse | 
+    Where-Object { $_.Name.StartsWith("Tests") } |
+    Where-Object { $_.BaseName -ne "TestsExplicit" } |
+    ForEach-Object { 
+
+        # Run dotnet test on the project and output the results in mstest format (also works for other frameworks like nunit)
+        & dotnet test $_.FullName --configuration $Config --no-build --no-restore --logger "trx;LogFilePrefix=test-results" 
+
+        $failed = $failed -or $LASTEXITCODE
+
+        $trxFiles = Get-ChildItem "$($_.Directory)\TestResults\*.trx"
+        # if on build server upload results to AppVeyor
+        if ("${ENV:APPVEYOR_JOB_ID}" -ne "") {
+            $wc = New-Object 'System.Net.WebClient'
+
+            $trxFiles | ForEach-Object {
+                $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $_.FullName))
+            }
+        }
+
+        # don't leave the test results lying around
+        $trxFiles | Remove-Item -ErrorAction SilentlyContinue
+}
+
+if ($failed) {
+    exit 1
+}


### PR DESCRIPTION
#### Description

Ensure unit test projects are run for all target frameworks (eg. .NET Core as well as .NET Framework)

#### The solution

Use a PowerShell script to find all test projects (except the TestsExplicit) and run  `dotnet test` on those. Test results are uploaded back to AppVeyor

Should resolve #263

#### Todos

 * [x] Related issues
 * [ ] Tests
 * [ ] Documentation