### PR TITLE
Use `ShouldCleanReference`

### DIFF
--- a/NullGuard.Fody/ModuleWeaver.cs
+++ b/NullGuard.Fody/ModuleWeaver.cs
@@ -17,6 +17,8 @@ public partial class ModuleWeaver: BaseModuleWeaver
     INullabilityAnalyzer nullabilityAnalyzer = new ImplicitModeAnalyzer();
     public Regex ExcludeRegex { get; set; }
 
+    public override bool ShouldCleanReference => true;
+
     public ModuleWeaver()
     {
         ValidationFlags = ValidationFlags.AllPublic;
@@ -63,7 +65,6 @@ public partial class ModuleWeaver: BaseModuleWeaver
         nullabilityAnalyzer.CheckForBadAttributes(types, WriteError);
         ProcessAssembly(types);
         RemoveAttributes(types);
-        RemoveReference();
     }
 
     public override IEnumerable<string> GetAssembliesForScanning()
@@ -188,18 +189,5 @@ public partial class ModuleWeaver: BaseModuleWeaver
                 property.RemoveAllNullGuardAttributes();
             }
         }
-    }
-
-    void RemoveReference()
-    {
-        var referenceToRemove = ModuleDefinition.AssemblyReferences.FirstOrDefault(x => x.Name == "NullGuard");
-        if (referenceToRemove == null)
-        {
-            WriteInfo("\tNo reference to 'NullGuard.dll' found. References not modified.");
-            return;
-        }
-
-        ModuleDefinition.AssemblyReferences.Remove(referenceToRemove);
-        WriteInfo("\tRemoving reference to 'NullGuard.dll'.");
     }
 }

--- a/NullGuard.sln.DotSettings
+++ b/NullGuard.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/Tests/ApprovedTests.InfosList.verified.txt
+++ b/Tests/ApprovedTests.InfosList.verified.txt
@@ -1,5 +1,5 @@
 [
   Mode=Implicit, ValidationFlags=AllPublic,
   Debug=False,
-  	Removing reference to 'NullGuard.dll'.
+  	Removing reference to 'NullGuard'.
 ]

--- a/TestsExplicit/ApprovedTests.InfosList.Core.Debug.verified.txt
+++ b/TestsExplicit/ApprovedTests.InfosList.Core.Debug.verified.txt
@@ -1,5 +1,5 @@
 [
-  'Mode=Explicit, ValidationFlags=AllPublic',
-  'Debug=False',
-  '\tRemoving reference to \'NullGuard.dll\'.'
+  Mode=Explicit, ValidationFlags=AllPublic,
+  Debug=False,
+  	Removing reference to 'NullGuard'.
 ]

--- a/TestsExplicit/ApprovedTests.InfosList.Core.Release.verified.txt
+++ b/TestsExplicit/ApprovedTests.InfosList.Core.Release.verified.txt
@@ -1,5 +1,5 @@
 [
-  'Mode=Explicit, ValidationFlags=AllPublic',
-  'Debug=False',
-  '\tRemoving reference to \'NullGuard.dll\'.'
+  Mode=Explicit, ValidationFlags=AllPublic,
+  Debug=False,
+  	Removing reference to 'NullGuard'.
 ]

--- a/TestsExplicit/ApprovedTests.InfosList.Net.Debug.verified.txt
+++ b/TestsExplicit/ApprovedTests.InfosList.Net.Debug.verified.txt
@@ -1,5 +1,5 @@
 [
   Mode=Explicit, ValidationFlags=AllPublic,
   Debug=False,
-  	Removing reference to 'NullGuard.dll'.
+  	Removing reference to 'NullGuard'.
 ]

--- a/TestsExplicit/ApprovedTests.InfosList.Net.Release.verified.txt
+++ b/TestsExplicit/ApprovedTests.InfosList.Net.Release.verified.txt
@@ -1,5 +1,5 @@
 [
-  'Mode=Explicit, ValidationFlags=AllPublic',
-  'Debug=False',
-  "\tRemoving reference to 'NullGuard.dll'."
+  Mode=Explicit, ValidationFlags=AllPublic,
+  Debug=False,
+  	Removing reference to 'NullGuard'.
 ]


### PR DESCRIPTION
Use `ShouldCleanReference` instead of the custom `RemoveReference` method.

See issue reported by @mikernet [on gitter](https://gitter.im/Fody/Fody?at=6094189ad5e2793379f6d1ae).

Note that I get different results for `TestsExplicit/ApprovedTests.SpecialClass.Core.Debug` on my machine (~so the CI will probably fail on this~), but that doesn't seem related to this PR.
